### PR TITLE
[g8NunjucksPage] Created Nunjucks template for basic page

### DIFF
--- a/.g8/page/app/controllers/$className$Controller.scala
+++ b/.g8/page/app/controllers/$className$Controller.scala
@@ -1,25 +1,36 @@
 package controllers
 
 import config.FrontendAppConfig
+import config.featureSwitch.{FeatureSwitching, UseNunjucks}
 import controllers.actions._
 import javax.inject.Inject
+import nunjucks.Renderer
+import nunjucks.$className$Template
 import play.api.i18n.{I18nSupport, MessagesApi}
-import play.api.mvc.{Action, AnyContent, MessagesControllerComponents}
+import play.api.mvc._
 import uk.gov.hmrc.play.bootstrap.controller.FrontendBaseController
 import views.html.$className$View
 
-import scala.concurrent.ExecutionContext
+import scala.concurrent.{ExecutionContext, Future}
 
 class $className$Controller @Inject()(override val messagesApi: MessagesApi,
                                       identify: IdentifierAction,
                                       getData: DataRetrievalAction,
                                       requireData: DataRequiredAction,
                                       val controllerComponents: MessagesControllerComponents,
-                                      view: $className$View
-                                     )(implicit ec: ExecutionContext, appConfig: FrontendAppConfig) extends FrontendBaseController with I18nSupport {
+                                      view: $className$View,
+                                      renderer: Renderer
+                                     )(implicit ec: ExecutionContext, appConfig: FrontendAppConfig)
+  extends FrontendBaseController with I18nSupport with FeatureSwitching {
 
-  def onPageLoad: Action[AnyContent] = (identify andThen getData andThen requireData) {
+  private def renderView(implicit request: Request[_]) = if(isEnabled(UseNunjucks)) {
+    renderer.render($className$Template)
+  } else {
+    Future.successful(view())
+  }
+
+  def onPageLoad: Action[AnyContent] = (identify andThen getData andThen requireData).async {
     implicit request =>
-      Ok(view())
+      renderView.map(Ok(_))
   }
 }

--- a/.g8/page/conf/views/$className$.njk
+++ b/.g8/page/conf/views/$className$.njk
@@ -1,0 +1,20 @@
+{% extends "includes/layout.njk" %}
+
+{% from "components/pageTitle.njk" import pageTitle %}
+{% from "components/h1/macro.njk" import h1 %}
+
+{% block pageTitle %}
+  {{ pageTitle(form, "$className;format="decap"$.title") }}
+{% endblock %}
+
+{% block content %}
+
+    <div class="govuk-grid-row">
+      <div class="govuk-grid-column-two-thirds">
+
+        {{ h1("$className;format="decap"$.heading") }}
+
+      </div>
+    </div>
+
+{% endblock %}

--- a/.g8/page/generated-test/controllers/$className$ControllerSpec.scala
+++ b/.g8/page/generated-test/controllers/$className$ControllerSpec.scala
@@ -17,11 +17,15 @@
 package controllers
 
 import base.SpecBase
+import config.featureSwitch.{FeatureSwitching, UseNunjucks}
 import controllers.actions.{DataRequiredActionImpl, FakeDataRetrievalActionEmptyAnswers, FakeIdentifierAction}
 import play.api.test.Helpers._
+import nunjucks.MockNunjucksRenderer
+import nunjucks.$className$Template
+import play.twirl.api.Html
 import views.html.$className$View
 
-class $className$ControllerSpec extends SpecBase {
+class $className$ControllerSpec extends SpecBase with MockNunjucksRenderer with FeatureSwitching {
 
   val view = injector.instanceOf[$className$View]
 
@@ -31,16 +35,36 @@ class $className$ControllerSpec extends SpecBase {
     getData = FakeDataRetrievalActionEmptyAnswers,
     requireData = new DataRequiredActionImpl,
     controllerComponents = messagesControllerComponents,
-    view = view
+    view = view,
+    mockNunjucksRenderer
   )
 
   "$className$ Controller" must {
 
-    "return OK and the correct view for a GET" in {
+    "When Nunjucks rendering is enabled" must {
 
-      val result = controller.onPageLoad(fakeRequest)
+      "return OK and the correct view for a GET" in {
 
-      status(result) mustBe OK
+        enable(UseNunjucks)
+
+        mockRender($className$Template)(Html("Success"))
+
+        val result = controller.onPageLoad(fakeRequest)
+
+        status(result) mustBe OK
+      }
+    }
+
+    "When Nunjucks rendering is disabled" must {
+
+      "return OK and the correct view for a GET" in {
+
+        disable(UseNunjucks)
+
+        val result = controller.onPageLoad(fakeRequest)
+
+        status(result) mustBe OK
+      }
     }
   }
 }

--- a/.g8/page/generated-test/views/$className$ViewSpec.scala
+++ b/.g8/page/generated-test/views/$className$ViewSpec.scala
@@ -2,17 +2,21 @@ package views
 
 import views.behaviours.ViewBehaviours
 import views.html.$className$View
+import nunjucks.$className$Template
 
 class $className$ViewSpec extends ViewBehaviours {
 
-  "$className$ view" must {
+  lazy val twirlViewTemplate = viewFor[$className$View](Some(emptyUserAnswers))
+  lazy val twirlView = twirlViewTemplate.apply()(fakeRequest, frontendAppConfig, messages)
+  lazy val nunjucksView = await(nunjucksRenderer.render($className$Template)(fakeRequest))
 
-    val view = viewFor[$className$View](Some(emptyUserAnswers))
+  Seq(twirlView -> "twirl", nunjucksView -> "nunjucks").foreach {
+    case (html, templatingSystem) =>
+      s"$className$View (\$templatingSystem)" must {
 
-    val applyView = view.apply()(fakeRequest, frontendAppConfig, messages)
+        behave like normalPage(html, "$className;format="decap"$")
 
-    behave like normalPage(applyView, "$className;format="decap"$")
-
-    behave like pageWithBackLink(applyView)
+        behave like pageWithBackLink(html)
+      }
   }
 }

--- a/.g8/page/migrations/$className__snake$.sh
+++ b/.g8/page/migrations/$className__snake$.sh
@@ -23,4 +23,7 @@ echo "# ----------------------------------------------------------" >> ../conf/m
 echo "$className;format="decap"$.title = $className;format="decap"$" >> ../conf/messages.cy
 echo "$className;format="decap"$.heading = $className;format="decap"$" >> ../conf/messages.cy
 
+echo "Adding template to Nunjucks templates"
+echo "object $className$Template extends WithName(\"$className;format="decap"$.njk\") with ViewTemplate" >> ../app/nunjucks/ViewTemplate.scala
+
 echo "Migration $className;format="snake"$ completed"

--- a/conf/views/checkYourAnswers.njk
+++ b/conf/views/checkYourAnswers.njk
@@ -1,6 +1,5 @@
 {% extends "includes/layout.njk" %}
 
-{% from "govuk/components/back-link/macro.njk"     import govukBackLink %}
 {% from "govuk/components/button/macro.njk"        import govukButton %}
 {% from "govuk/components/summary-list/macro.njk"  import govukSummaryList %}
 

--- a/conf/views/components/h1/macro.njk
+++ b/conf/views/components/h1/macro.njk
@@ -1,0 +1,3 @@
+{% macro h1(heading) %}
+    {% include "components/h1/template.njk" %}
+{% endmacro %}

--- a/conf/views/components/h1/template.njk
+++ b/conf/views/components/h1/template.njk
@@ -1,0 +1,1 @@
+<h1 class="govuk-heading-xl">{{ messages(heading) }}</h1>

--- a/conf/views/helloWorldYesNo.njk
+++ b/conf/views/helloWorldYesNo.njk
@@ -1,6 +1,5 @@
 {% extends "includes/layout.njk" %}
 
-{% from "govuk/components/back-link/macro.njk"     import govukBackLink %}
 {% from "govuk/components/button/macro.njk"        import govukButton %}
 
 {% from "components/errorSummary.njk" import errorSummary %}

--- a/conf/views/includes/layout.njk
+++ b/conf/views/includes/layout.njk
@@ -2,6 +2,7 @@
 {%- set assetPath = "/assets/lib/govuk-frontend/govuk/assets" -%}
 
 {% from "components/phaseBanner/macro.njk" import phaseBanner %}
+{% from "govuk/components/back-link/macro.njk"     import govukBackLink %}
 
 {% block head %}
   {% include "includes/head.njk" %}

--- a/test/nunjucks/MockNunjucksRenderer.scala
+++ b/test/nunjucks/MockNunjucksRenderer.scala
@@ -29,6 +29,10 @@ trait MockNunjucksRenderer extends MockitoSugar {
 
   lazy val mockNunjucksRenderer: Renderer = mock[Renderer]
 
+  def mockRender(template: String)(htmlResponse: Html): OngoingStubbing[Future[Html]] =
+    when(mockNunjucksRenderer.render(Matchers.eq(template))(Matchers.any()))
+      .thenReturn(Future.successful(htmlResponse))
+
   def mockRender(template: String, context: JsObject)(htmlResponse: Html): OngoingStubbing[Future[Html]] =
     when(mockNunjucksRenderer.render(Matchers.eq(template), Matchers.eq(context))(Matchers.any()))
     .thenReturn(Future.successful(htmlResponse))


### PR DESCRIPTION
For the basic `page` g8Scaffold this PR now adds the Nunjucks template in addition to the existing twirl template. With associated tests to confirm that the two views render correctly and the controller can render both twirl and nunjucks.

This can be used as the basis for starting to update the other scaffolds to include Nunjucks templating.