### PR TITLE
CIR-1244 - Fix generator issue. Tidied up warnings.

### DIFF
--- a/app/config/FrontendAppConfig.scala
+++ b/app/config/FrontendAppConfig.scala
@@ -23,7 +23,7 @@ import models.returnModels.CountryCodeModel
 import play.api.Environment
 import play.api.libs.json.{JsSuccess, Json}
 import play.api.mvc.{Call, RequestHeader}
-import uk.gov.hmrc.play.binders.ContinueUrl
+import uk.gov.hmrc.play.bootstrap.binders.SafeRedirectUrl
 import uk.gov.hmrc.play.bootstrap.config.ServicesConfig
 
 @Singleton
@@ -40,7 +40,7 @@ class FrontendAppConfig @Inject()(val servicesConfig: ServicesConfig, environmen
   val reportAProblemPartialUrl = s"$contactHost/contact/problem_reports_ajax?service=$contactFormServiceIdentifier"
   val reportAProblemNonJSUrl = s"$contactHost/contact/problem_reports_nonjs?service=$contactFormServiceIdentifier"
 
-  private def requestUri(implicit request: RequestHeader) = ContinueUrl(host + request.uri).encodedUrl
+  private def requestUri(implicit request: RequestHeader) = SafeRedirectUrl(host + request.uri).encodedUrl
   def feedbackUrl(implicit request: RequestHeader): String =
     s"$contactHost/contact/beta-feedback?service=$contactFormServiceIdentifier&backUrl=$requestUri"
 

--- a/app/controllers/BaseController.scala
+++ b/app/controllers/BaseController.scala
@@ -42,7 +42,7 @@ trait BaseController extends FrontendBaseController with I18nSupport with Enumer
   def fillForm[A](page: QuestionPage[A], form: Form[A])(implicit request: DataRequest[_], format: Format[A]): Form[A] =
     fillForm(page, form, None)
 
-  private def fillForm[A](page: QuestionPage[A], form: Form[A], idx: Option[Int] = None)(implicit request: DataRequest[_], format: Format[A]): Form[A] =
+  private def fillForm[A](page: QuestionPage[A], form: Form[A], idx: Option[Int])(implicit request: DataRequest[_], format: Format[A]): Form[A] =
     request.userAnswers.get(page, idx).fold(form)(form.fill)
 
   def answerFor[A](page: QuestionPage[A], idx: Int)(f: A => Future[Result])

--- a/app/controllers/SignOutController.scala
+++ b/app/controllers/SignOutController.scala
@@ -23,11 +23,11 @@ import play.api.mvc.{Action, AnyContent, MessagesControllerComponents}
 class SignOutController @Inject()(val controllerComponents: MessagesControllerComponents,
                                   appConfig: FrontendAppConfig) extends BaseController {
 
-  def signOut: Action[AnyContent] = Action { implicit request =>
+  def signOut: Action[AnyContent] = Action { _ =>
     Redirect(appConfig.signOutUrl, Map("continue" -> Seq(appConfig.exitSurveyUrl)))
   }
 
-  def signOutNoSurvey: Action[AnyContent] = Action { implicit request =>
+  def signOutNoSurvey: Action[AnyContent] = Action { _ =>
     Redirect(appConfig.signOutUrl, Map("continue" -> Seq(appConfig.host + controllers.errors.routes.SessionExpiredController.onPageLoad().url)))
   }
 }

--- a/app/controllers/checkTotals/DerivedCompanyController.scala
+++ b/app/controllers/checkTotals/DerivedCompanyController.scala
@@ -28,7 +28,6 @@ import pages.ukCompanies.{DerivedCompanyPage, UkCompaniesPage}
 import play.api.Logging
 import play.api.i18n.MessagesApi
 import play.api.mvc._
-import repositories.SessionRepository
 import utils.CheckTotalsHelper
 import views.html.checkTotals.DerivedCompanyView
 

--- a/app/controllers/elections/InvestorGroupNameController.scala
+++ b/app/controllers/elections/InvestorGroupNameController.scala
@@ -20,7 +20,7 @@ import controllers.actions._
 import forms.elections.InvestorGroupNameFormProvider
 
 import javax.inject.Inject
-import models.{Mode, NormalMode}
+import models.Mode
 import pages.elections.{InvestorGroupNamePage, InvestorGroupsPage}
 import play.api.i18n.MessagesApi
 import play.api.mvc._

--- a/app/controllers/elections/InvestorGroupsReviewAnswersListController.scala
+++ b/app/controllers/elections/InvestorGroupsReviewAnswersListController.scala
@@ -28,7 +28,6 @@ import pages.elections.InvestorGroupsPage
 import play.api.data.Form
 import play.api.i18n.MessagesApi
 import play.api.mvc._
-import repositories.SessionRepository
 import utils.InvestorGroupsReviewAnswersListHelper
 import views.html.elections.InvestorGroupsReviewAnswersListView
 

--- a/app/controllers/elections/InvestorRatioMethodController.scala
+++ b/app/controllers/elections/InvestorRatioMethodController.scala
@@ -24,7 +24,7 @@ import forms.elections.InvestorRatioMethodFormProvider
 import handlers.ErrorHandler
 
 import javax.inject.Inject
-import models.{InvestorRatioMethod, Mode, NormalMode}
+import models.{InvestorRatioMethod, Mode}
 import navigation.ElectionsNavigator
 import pages.elections.{InvestorGroupsPage, InvestorRatioMethodPage}
 import play.api.i18n.MessagesApi

--- a/app/controllers/elections/OtherInvestorGroupElectionsController.scala
+++ b/app/controllers/elections/OtherInvestorGroupElectionsController.scala
@@ -24,7 +24,7 @@ import handlers.ErrorHandler
 
 import javax.inject.Inject
 import models.returnModels.InvestorGroupModel
-import models.{InvestorRatioMethod, Mode, NormalMode}
+import models.{InvestorRatioMethod, Mode}
 import navigation.ElectionsNavigator
 import pages.elections.{InvestorGroupsPage, OtherInvestorGroupElectionsPage}
 import play.api.i18n.MessagesApi

--- a/app/controllers/elections/PartnershipsReviewAnswersListController.scala
+++ b/app/controllers/elections/PartnershipsReviewAnswersListController.scala
@@ -30,7 +30,6 @@ import pages.elections.PartnershipsReviewAnswersListPage
 import play.api.data.Form
 import play.api.i18n.MessagesApi
 import play.api.mvc._
-import repositories.SessionRepository
 import uk.gov.hmrc.govukfrontend.views.viewmodels.summarylist.SummaryListRow
 import utils.PartnershipsReviewAnswersListHelper
 import views.html.elections.PartnershipsReviewAnswersListView

--- a/app/controllers/reviewAndComplete/ReviewAndCompleteController.scala
+++ b/app/controllers/reviewAndComplete/ReviewAndCompleteController.scala
@@ -20,7 +20,6 @@ import config.FrontendAppConfig
 import config.featureSwitch.FeatureSwitching
 import controllers.BaseController
 import controllers.actions._
-import handlers.ErrorHandler
 
 import javax.inject.Inject
 import models.NormalMode
@@ -41,7 +40,7 @@ class ReviewAndCompleteController @Inject()(override val messagesApi: MessagesAp
                                             requireData: DataRequiredAction,
                                             val controllerComponents: MessagesControllerComponents,
                                             view: ReviewAndCompleteView
-                                           )(implicit appConfig: FrontendAppConfig, errorHandler: ErrorHandler)
+                                           )(implicit appConfig: FrontendAppConfig)
   extends BaseController with I18nSupport with FeatureSwitching {
 
 

--- a/app/controllers/ultimateParentCompany/CountryOfIncorporationController.scala
+++ b/app/controllers/ultimateParentCompany/CountryOfIncorporationController.scala
@@ -23,7 +23,7 @@ import forms.ultimateParentCompany.CountryOfIncorporationFormProvider
 import handlers.ErrorHandler
 
 import javax.inject.Inject
-import models.{Mode, NormalMode}
+import models.Mode
 import models.returnModels.CountryCodeModel
 import navigation.UltimateParentCompanyNavigator
 import pages.ultimateParentCompany.{CountryOfIncorporationPage, DeemedParentPage}

--- a/app/controllers/ultimateParentCompany/LimitedLiabilityPartnershipController.scala
+++ b/app/controllers/ultimateParentCompany/LimitedLiabilityPartnershipController.scala
@@ -24,7 +24,7 @@ import forms.ultimateParentCompany.LimitedLiabilityPartnershipFormProvider
 import handlers.ErrorHandler
 
 import javax.inject.Inject
-import models.{Mode, NormalMode}
+import models.Mode
 import navigation.UltimateParentCompanyNavigator
 import pages.ultimateParentCompany.{DeemedParentPage, LimitedLiabilityPartnershipPage}
 import play.api.i18n.MessagesApi

--- a/app/controllers/ultimateParentCompany/ParentCompanyCTUTRController.scala
+++ b/app/controllers/ultimateParentCompany/ParentCompanyCTUTRController.scala
@@ -24,7 +24,7 @@ import forms.ultimateParentCompany.ParentCompanyCTUTRFormProvider
 import handlers.ErrorHandler
 
 import javax.inject.Inject
-import models.{Mode, NormalMode}
+import models.Mode
 import models.returnModels.UTRModel
 import navigation.UltimateParentCompanyNavigator
 import pages.ultimateParentCompany.{DeemedParentPage, ParentCompanyCTUTRPage}

--- a/app/controllers/ultimateParentCompany/ParentCompanyNameController.scala
+++ b/app/controllers/ultimateParentCompany/ParentCompanyNameController.scala
@@ -23,7 +23,7 @@ import controllers.actions._
 import forms.ultimateParentCompany.ParentCompanyNameFormProvider
 
 import javax.inject.Inject
-import models.{Mode, NormalMode}
+import models.Mode
 import models.returnModels.{CompanyNameModel, DeemedParentModel}
 import navigation.UltimateParentCompanyNavigator
 import pages.ultimateParentCompany.{DeemedParentPage, ParentCompanyNamePage}

--- a/app/controllers/ultimateParentCompany/ParentCompanySAUTRController.scala
+++ b/app/controllers/ultimateParentCompany/ParentCompanySAUTRController.scala
@@ -24,7 +24,7 @@ import forms.ultimateParentCompany.ParentCompanySAUTRFormProvider
 import handlers.ErrorHandler
 
 import javax.inject.Inject
-import models.{Mode, NormalMode}
+import models.Mode
 import models.returnModels.UTRModel
 import navigation.UltimateParentCompanyNavigator
 import pages.ultimateParentCompany.{DeemedParentPage, ParentCompanySAUTRPage}

--- a/app/controllers/ultimateParentCompany/PayTaxInUkController.scala
+++ b/app/controllers/ultimateParentCompany/PayTaxInUkController.scala
@@ -24,7 +24,7 @@ import forms.ultimateParentCompany.PayTaxInUkFormProvider
 import handlers.ErrorHandler
 
 import javax.inject.Inject
-import models.{Mode, NormalMode}
+import models.Mode
 import navigation.UltimateParentCompanyNavigator
 import pages.ultimateParentCompany.{DeemedParentPage, PayTaxInUkPage}
 import play.api.i18n.MessagesApi

--- a/app/models/returnModels/ReviewAndCompleteModel.scala
+++ b/app/models/returnModels/ReviewAndCompleteModel.scala
@@ -42,6 +42,9 @@ case class ReviewAndCompleteModel(aboutReturn: SectionState = SectionState(),
     case Section.UltimateParentCompany => this.copy(ultimateParentCompany = SectionState(sectionStatus, Some(page)))
     case Section.UkCompanies => this.copy(ukCompanies = SectionState(sectionStatus, Some(page)))
     case Section.CheckTotals => this.copy(checkTotals = SectionState(sectionStatus, Some(page)))
+    case Section.ReviewTaxEBITDA => throw new Exception("Not yet implemented")
+    case Section.ReviewReactivations => throw new Exception("Not yet implemented")
+    case Section.ReviewAndComplete => throw new Exception("Not yet implemented")
   }
 }
 

--- a/app/navigation/AboutReturnNavigator.scala
+++ b/app/navigation/AboutReturnNavigator.scala
@@ -75,5 +75,6 @@ class AboutReturnNavigator @Inject()() extends Navigator {
   def nextPage(page: Page, mode: Mode, userAnswers: UserAnswers, id: Option[Int] = None): Call = mode match {
     case NormalMode => normalRoutes(page)(userAnswers)
     case CheckMode => checkRouteMap(page)(userAnswers)
+    case ReviewMode => normalRoutes(page)(userAnswers)
   }
 }

--- a/app/navigation/CheckTotalsNavigator.scala
+++ b/app/navigation/CheckTotalsNavigator.scala
@@ -36,7 +36,7 @@ class CheckTotalsNavigator @Inject()() extends Navigator {
   )
 
   //TODO update with CYA call
-  private def checkYourAnswers: Call = controllers.routes.UnderConstructionController.onPageLoad()
+  //private def checkYourAnswers: Call = controllers.routes.UnderConstructionController.onPageLoad()
 
   //TODO update with Next Section call
   private def nextSection: Call = controllers.reviewAndComplete.routes.ReviewAndCompleteController.onPageLoad()

--- a/app/navigation/ElectionsNavigator.scala
+++ b/app/navigation/ElectionsNavigator.scala
@@ -129,5 +129,6 @@ class ElectionsNavigator @Inject()() extends Navigator {
   def nextPage(page: Page, mode: Mode, userAnswers: UserAnswers, id: Option[Int] = None): Call = mode match {
     case NormalMode => id.fold(normalRoutes(page)(userAnswers))(idx => idxRoutes(page)(idx, userAnswers))
     case CheckMode => checkRouteMap(page)(userAnswers)
+    case ReviewMode => id.fold(normalRoutes(page)(userAnswers))(idx => idxRoutes(page)(idx, userAnswers))
   }
 }

--- a/app/navigation/GroupLevelInformationNavigator.scala
+++ b/app/navigation/GroupLevelInformationNavigator.scala
@@ -19,11 +19,8 @@ package navigation
 import javax.inject.{Inject, Singleton}
 import controllers.groupLevelInformation.{routes => groupLevelInformationRoutes}
 import controllers.ukCompanies.{routes => ukCompaniesRoutes}
-import controllers.routes
-import models.FullOrAbbreviatedReturn.{Abbreviated, Full}
 import models._
 import pages._
-import pages.aboutReturn.FullOrAbbreviatedReturnPage
 import pages.groupLevelInformation._
 import play.api.mvc.Call
 
@@ -57,5 +54,6 @@ class GroupLevelInformationNavigator @Inject()() extends Navigator {
   def nextPage(page: Page, mode: Mode, userAnswers: UserAnswers, id: Option[Int] = None): Call = mode match {
     case NormalMode => normalRoutes(page)(userAnswers)
     case CheckMode => checkRouteMap(page)(userAnswers)
+    case ReviewMode => normalRoutes(page)(userAnswers)
   }
 }

--- a/app/navigation/UltimateParentCompanyNavigator.scala
+++ b/app/navigation/UltimateParentCompanyNavigator.scala
@@ -69,5 +69,6 @@ class UltimateParentCompanyNavigator @Inject()() extends Navigator {
   def nextPage(page: Page, mode: Mode, userAnswers: UserAnswers, idx: Option[Int] = None): Call = mode match {
     case NormalMode => normalRoutes(page)(idx.getOrElse[Int](1), userAnswers)
     case CheckMode => checkRouteMap(page)(idx.getOrElse[Int](1), userAnswers)
+    case ReviewMode => normalRoutes(page)(idx.getOrElse[Int](1), userAnswers)
   }
 }

--- a/it/controllers/ConfirmationControllerISpec.scala
+++ b/it/controllers/ConfirmationControllerISpec.scala
@@ -18,9 +18,7 @@ package controllers
 
 import assets.{BaseITConstants, PageTitles}
 import config.SessionKeys
-import models.NormalMode
 import play.api.http.Status._
-import play.api.libs.json.Json
 import stubs.AuthStub
 import utils.{CreateRequestHelper, CustomMatchers, IntegrationSpecBase}
 

--- a/it/controllers/SavedReturnControllerISpec.scala
+++ b/it/controllers/SavedReturnControllerISpec.scala
@@ -17,8 +17,6 @@
 package controllers
 
 import assets.{BaseITConstants, PageTitles}
-import models.NormalMode
-import pages.aboutReturn.ReportingCompanyAppointedPage
 import play.api.http.Status._
 import stubs.AuthStub
 import utils.{CreateRequestHelper, CustomMatchers, IntegrationSpecBase}

--- a/it/controllers/aboutReturn/CheckAnswersAboutReturnControllerISpec.scala
+++ b/it/controllers/aboutReturn/CheckAnswersAboutReturnControllerISpec.scala
@@ -19,7 +19,7 @@ package controllers.aboutReturn
 import assets.{BaseITConstants, PageTitles}
 import models.NormalMode
 import play.api.http.Status._
-import play.api.libs.json.{JsString, Json}
+import play.api.libs.json.JsString
 import stubs.AuthStub
 import utils.{CreateRequestHelper, CustomMatchers, IntegrationSpecBase}
 

--- a/it/controllers/elections/InvestmentNameControllerISpec.scala
+++ b/it/controllers/elections/InvestmentNameControllerISpec.scala
@@ -17,7 +17,6 @@
 package controllers.elections
 
 import assets.{BaseITConstants, PageTitles}
-import models.NormalMode
 import play.api.http.Status._
 import play.api.libs.json.Json
 import stubs.AuthStub

--- a/it/controllers/elections/InvestmentsReviewAnswersListControllerISpec.scala
+++ b/it/controllers/elections/InvestmentsReviewAnswersListControllerISpec.scala
@@ -20,7 +20,7 @@ import assets.NonConsolidatedInvestmentsITConstants._
 import assets.{BaseITConstants, PageTitles}
 import models.NormalMode
 import pages.elections.InvestmentNamePage
-import pages.ultimateParentCompany.{DeemedParentPage, HasDeemedParentPage}
+import pages.ultimateParentCompany.HasDeemedParentPage
 import play.api.http.Status._
 import play.api.libs.json.Json
 import stubs.AuthStub

--- a/it/controllers/elections/OtherInvestorGroupElectionsControllerISpec.scala
+++ b/it/controllers/elections/OtherInvestorGroupElectionsControllerISpec.scala
@@ -18,10 +18,8 @@ package controllers.elections
 
 import assets.InvestorGroupITConstants.{investorGroupsFixedRatioModel, investorGroupsGroupRatioModel}
 import assets.{BaseITConstants, PageTitles}
-import models.InvestorRatioMethod.FixedRatioMethod
-import models.NormalMode
 import models.OtherInvestorGroupElections.GroupEBITDA
-import pages.elections.{InvestorGroupsPage, InvestorRatioMethodPage}
+import pages.elections.InvestorGroupsPage
 import play.api.http.Status._
 import play.api.libs.json.Json
 import stubs.AuthStub

--- a/it/controllers/elections/QICElectionPageControllerISpec.scala
+++ b/it/controllers/elections/QICElectionPageControllerISpec.scala
@@ -17,7 +17,6 @@
 package controllers.elections
 
 import assets.{BaseITConstants, PageTitles}
-import models.NormalMode
 import play.api.http.Status._
 import play.api.libs.json.Json
 import stubs.AuthStub

--- a/it/controllers/groupLevelInformation/GroupInterestCapacityControllerISpec.scala
+++ b/it/controllers/groupLevelInformation/GroupInterestCapacityControllerISpec.scala
@@ -17,7 +17,6 @@
 package controllers.groupLevelInformation
 
 import assets.{BaseITConstants, PageTitles}
-import models.NormalMode
 import play.api.http.Status._
 import play.api.libs.json.Json
 import stubs.AuthStub

--- a/it/controllers/ukCompanies/AddRestrictionControllerISpec.scala
+++ b/it/controllers/ukCompanies/AddRestrictionControllerISpec.scala
@@ -18,7 +18,6 @@ package controllers.ukCompanies
 
 import assets.UkCompanyITConstants.ukCompanyModelMax
 import assets.{BaseITConstants, PageTitles}
-import models.NormalMode
 import pages.ukCompanies.UkCompaniesPage
 import play.api.http.Status._
 import play.api.libs.json.Json

--- a/it/controllers/ukCompanies/EnterCompanyTaxEBITDAControllerISpec.scala
+++ b/it/controllers/ukCompanies/EnterCompanyTaxEBITDAControllerISpec.scala
@@ -19,7 +19,6 @@ package controllers.ukCompanies
 import assets.UkCompanyITConstants._
 import assets.{BaseITConstants, PageTitles}
 import pages.ukCompanies.UkCompaniesPage
-import controllers.ukCompanies.{routes => ukCompanies}
 import models.NormalMode
 import play.api.http.Status._
 import play.api.libs.json.Json

--- a/it/controllers/ukCompanies/NetTaxInterestAmountControllerISpec.scala
+++ b/it/controllers/ukCompanies/NetTaxInterestAmountControllerISpec.scala
@@ -16,7 +16,7 @@
 
 package controllers.ukCompanies
 
-import assets.UkCompanyITConstants.{ukCompanyModelMax, ukCompanyModelMin}
+import assets.UkCompanyITConstants.ukCompanyModelMin
 import assets.{BaseITConstants, PageTitles}
 import models.NetTaxInterestIncomeOrExpense.NetTaxInterestIncome
 import models.NormalMode

--- a/it/controllers/ukCompanies/ReactivationAmountControllerISpec.scala
+++ b/it/controllers/ukCompanies/ReactivationAmountControllerISpec.scala
@@ -18,7 +18,6 @@ package controllers.ukCompanies
 
 import assets.UkCompanyITConstants.ukCompanyModelMax
 import assets.{BaseITConstants, PageTitles}
-import models.NormalMode
 import pages.ukCompanies.UkCompaniesPage
 import play.api.http.Status._
 import play.api.libs.json.Json

--- a/it/controllers/ultimateParentCompany/DeletionConfirmationControllerISpec.scala
+++ b/it/controllers/ultimateParentCompany/DeletionConfirmationControllerISpec.scala
@@ -18,7 +18,6 @@ package controllers.ultimateParentCompany
 
 import assets.{BaseITConstants, PageTitles}
 import assets.DeemedParentITConstants._
-import models.NormalMode
 import pages.ultimateParentCompany.{DeemedParentPage, HasDeemedParentPage}
 import play.api.http.Status._
 import play.api.libs.json.Json

--- a/it/controllers/ultimateParentCompany/ParentCompanyCTUTRControllerISpec.scala
+++ b/it/controllers/ultimateParentCompany/ParentCompanyCTUTRControllerISpec.scala
@@ -23,7 +23,6 @@ import play.api.libs.json.Json
 import stubs.AuthStub
 import utils.{CreateRequestHelper, CustomMatchers, IntegrationSpecBase}
 import controllers.ultimateParentCompany.{routes => ultimateParentCompanyRoutes}
-import models.NormalMode
 import pages.ultimateParentCompany.DeemedParentPage
 
 class ParentCompanyCTUTRControllerISpec extends IntegrationSpecBase with CreateRequestHelper with CustomMatchers with BaseITConstants {

--- a/it/controllers/ultimateParentCompany/ParentCompanySAUTRControllerISpec.scala
+++ b/it/controllers/ultimateParentCompany/ParentCompanySAUTRControllerISpec.scala
@@ -23,7 +23,6 @@ import play.api.libs.json.Json
 import stubs.AuthStub
 import utils.{CreateRequestHelper, CustomMatchers, IntegrationSpecBase}
 import controllers.ultimateParentCompany.{routes => ultimateParentCompanyRoutes}
-import models.NormalMode
 import pages.ultimateParentCompany.DeemedParentPage
 
 class ParentCompanySAUTRControllerISpec extends IntegrationSpecBase with CreateRequestHelper with CustomMatchers with BaseITConstants {

--- a/it/utils/CreateRequestHelper.scala
+++ b/it/utils/CreateRequestHelper.scala
@@ -1,10 +1,9 @@
 package utils
 
-import config.SessionKeys
 import org.scalatestplus.play.ServerProvider
 import play.api.Application
 import play.api.http.HeaderNames
-import play.api.libs.json.{JsValue, Json}
+import play.api.libs.json.JsValue
 import play.api.libs.ws.{DefaultWSCookie, WSClient, WSResponse}
 
 import scala.concurrent.Future

--- a/it/utils/IntegrationSpecBase.scala
+++ b/it/utils/IntegrationSpecBase.scala
@@ -7,7 +7,6 @@ import org.scalatest.concurrent.{Eventually, IntegrationPatience, ScalaFutures}
 import org.scalatest.{TryValues, _}
 import org.scalatestplus.play.guice.GuiceOneServerPerSuite
 import pages.QuestionPage
-import play.api.http.Status.OK
 import play.api.inject.guice.GuiceApplicationBuilder
 import play.api.libs.json.{Json, Reads, Writes}
 import play.api.{Application, Environment, Mode}
@@ -16,7 +15,6 @@ import stubs.AuthStub
 
 import scala.concurrent.Await
 import scala.concurrent.duration.Duration
-import scala.util.Try
 
 trait IntegrationSpecBase extends WordSpec
   with GivenWhenThen with TestSuite with ScalaFutures with IntegrationPatience with Matchers
@@ -48,7 +46,7 @@ trait IntegrationSpecBase extends WordSpec
   def setAnswers(userAnswers: UserAnswers)(implicit timeout: Duration): Unit = Await.result(mongo.set(userAnswers), timeout)
   def getAnswers(id: String)(implicit timeout: Duration): Option[UserAnswers] = Await.result(mongo.get(id), timeout)
 
-  def setAnswers[A](page: QuestionPage[A], value: A)(implicit writes: Writes[A], timeout: Duration): Unit =
+  def setAnswers[A](page: QuestionPage[A], value: A)(implicit writes: Writes[A]): Unit =
     setAnswers(emptyUserAnswers.set(page, value).success.value)
 
   def appendList[A](page: QuestionPage[A], value: A)(implicit writes: Writes[A], rds: Reads[A]): Unit = {

--- a/test/controllers/SignOutControllerSpec.scala
+++ b/test/controllers/SignOutControllerSpec.scala
@@ -18,7 +18,7 @@ package controllers
 
 import base.SpecBase
 import play.api.test.Helpers._
-import uk.gov.hmrc.play.binders.ContinueUrl
+import uk.gov.hmrc.play.bootstrap.binders.SafeRedirectUrl
 
 class SignOutControllerSpec extends SpecBase {
 
@@ -36,7 +36,7 @@ class SignOutControllerSpec extends SpecBase {
         val result = TestSignOutController.signOut(fakeRequest)
 
         status(result) mustEqual SEE_OTHER
-        redirectLocation(result) mustBe Some(frontendAppConfig.signOutUrl + s"?continue=${ContinueUrl(frontendAppConfig.exitSurveyUrl).encodedUrl}")
+        redirectLocation(result) mustBe Some(frontendAppConfig.signOutUrl + s"?continue=${SafeRedirectUrl(frontendAppConfig.exitSurveyUrl).encodedUrl}")
       }
     }
 
@@ -48,7 +48,7 @@ class SignOutControllerSpec extends SpecBase {
 
         status(result) mustEqual SEE_OTHER
         redirectLocation(result) mustBe Some(frontendAppConfig.signOutUrl +
-          s"?continue=${ContinueUrl(frontendAppConfig.host + controllers.errors.routes.SessionExpiredController.onPageLoad().url).encodedUrl}")
+          s"?continue=${SafeRedirectUrl(frontendAppConfig.host + controllers.errors.routes.SessionExpiredController.onPageLoad().url).encodedUrl}")
       }
     }
   }

--- a/test/controllers/groupLevelInformation/DisallowedAmountControllerSpec.scala
+++ b/test/controllers/groupLevelInformation/DisallowedAmountControllerSpec.scala
@@ -22,7 +22,6 @@ import config.featureSwitch.FeatureSwitching
 import controllers.actions._
 import forms.groupLevelInformation.DisallowedAmountFormProvider
 import models.NormalMode
-import pages.groupLevelInformation.DisallowedAmountPage
 import play.api.test.Helpers._
 import views.html.groupLevelInformation.DisallowedAmountView
 import navigation.FakeNavigators.FakeGroupLevelInformationNavigator

--- a/test/forms/elections/PartnershipSAUTRFormProviderSpec.scala
+++ b/test/forms/elections/PartnershipSAUTRFormProviderSpec.scala
@@ -17,7 +17,6 @@
 package forms.elections
 
 import forms.behaviours.StringFieldBehaviours
-import play.api.data.FormError
 
 class PartnershipSAUTRFormProviderSpec extends StringFieldBehaviours {
 

--- a/test/generators/Generators.scala
+++ b/test/generators/Generators.scala
@@ -85,12 +85,12 @@ trait Generators extends UserAnswersGenerator with PageGenerators with ModelGene
 
   def nonBooleans: Gen[String] =
     arbitrary[String]
-      .suchThat (_.nonEmpty)
+      .suchThat (_.trim.length != 0)
       .suchThat (_ != "true")
       .suchThat (_ != "false")
 
   def nonEmptyString: Gen[String] =
-    arbitrary[String] suchThat (_.nonEmpty)
+    arbitrary[String] suchThat (_.trim.length != 0)
 
   def stringsWithMaxLength(maxLength: Int): Gen[String] =
     for {

--- a/test/navigation/GroupLevelInformationNavigatorSpec.scala
+++ b/test/navigation/GroupLevelInformationNavigatorSpec.scala
@@ -19,10 +19,8 @@ package navigation
 import base.SpecBase
 import controllers.groupLevelInformation.{routes => groupLevelInformationRoutes}
 import controllers.ukCompanies.{routes => ukCompaniesRoutes}
-import models.FullOrAbbreviatedReturn.{Abbreviated, Full}
 import models.{CheckMode, NormalMode, UserAnswers}
 import pages.Page
-import pages.aboutReturn.FullOrAbbreviatedReturnPage
 import pages.groupLevelInformation._
 
 class GroupLevelInformationNavigatorSpec extends SpecBase {

--- a/test/pages/aboutReturn/AgentNamePageSpec.scala
+++ b/test/pages/aboutReturn/AgentNamePageSpec.scala
@@ -16,8 +16,6 @@
 
 package pages.aboutReturn
 
-import models.UserAnswers
-import org.scalacheck.Arbitrary.arbitrary
 import pages.behaviours.PageBehaviours
 
 

--- a/test/pages/groupLevelInformation/RevisingReturnPageSpec.scala
+++ b/test/pages/groupLevelInformation/RevisingReturnPageSpec.scala
@@ -19,7 +19,7 @@ package pages.groupLevelInformation
 import models.UserAnswers
 import pages.behaviours.PageBehaviours
 import org.scalacheck.Arbitrary.arbitrary
-import pages.aboutReturn.{AgentNamePage, TellUsWhatHasChangedPage}
+import pages.aboutReturn.TellUsWhatHasChangedPage
 
 class RevisingReturnPageSpec extends PageBehaviours {
 

--- a/test/utils/InvestorGroupsReviewAnswersListHelperSpec.scala
+++ b/test/utils/InvestorGroupsReviewAnswersListHelperSpec.scala
@@ -18,7 +18,6 @@ package utils
 
 import assets.constants.InvestorGroupConstants._
 import assets.messages.BaseMessages
-import assets.messages.elections.InvestorGroupsReviewAnswersListMessages
 import base.SpecBase
 import controllers.elections.routes
 import models.NormalMode


### PR DESCRIPTION
**Fixed potential generator issues**
test/generators/Generators.scala
The generators checked if a string was nonEmpty when generating an invalid string (same for boolean). However, the formatters trim the string and check if the length is zero when determining if it's empty. This means the generator might generate a test value of `\n` which it expects to result in an "invalid" error message, but because the formatter trims this away in actuality it results in a "required" error message.

So now the generators match the formatter logic and won't generate values which might trim to length zero.

**Tidied up compilation warnings**
Changed deprecated ContinueUrl to RedirectUrl
Removed plenty of unused imports, and some unused params.

**Possible contentious one:**
app/models/returnModels/ReviewAndCompleteModel.scala
Here we have a match statement which doesn't check all cases of the sealed trait. This means if we pass in one of those unchecked values a pattern matching exception will be thrown. This ends up being really confusing to investigate and sometimes not obvious.

My temporary solution is not a pretty one though - I don't know if these items need to be added to our ReviewAndCompleteModel even though they are sections that exist, so in the meantime I've got it checking all possibilities but throwing a really generic exception which will hopefully be more obvious if we hit it. And we remove the warning. 

We'll be looking at this when we fix the review model anyway I'd imagine.