### PR TITLE
CIR-1021

### DIFF
--- a/app/utils/CheckTotalsHelper.scala
+++ b/app/utils/CheckTotalsHelper.scala
@@ -26,25 +26,46 @@ class CheckTotalsHelper extends SummaryListRowHelper with CurrencyFormatter {
 
   def constructTotalsTable(ukCompanies: Seq[UkCompanyModel])(implicit messages: Messages): Seq[SummaryListRow] = {
     val derivedData = calculateSums(ukCompanies)
-    val numberOfUkCompanies = Some(summaryListRow(messages("derivedCompany.t1"),
-      derivedData.ukCompaniesLength.toString,(controllers.ukCompanies.routes.UkCompaniesReviewAnswersListController.onPageLoad(),messages("site.review"))))
-    val aggregateTaxEBITDA = Some(summaryListRow(messages("derivedCompany.t2"),
-      currencyFormat(derivedData.aggregateEbitda),(controllers.checkTotals.routes.ReviewTaxEBITDAController.onPageLoad(),messages("site.review"))))
+
+    val numberOfUkCompanies = Some(summaryListRow(
+      messages("derivedCompany.t1"),
+      derivedData.ukCompaniesLength.toString,
+      visuallyHiddenText = None,
+      (controllers.ukCompanies.routes.UkCompaniesReviewAnswersListController.onPageLoad(),messages("site.review"))))
+
+    val aggregateTaxEBITDA = Some(summaryListRow(
+      messages("derivedCompany.t2"),
+      currencyFormat(derivedData.aggregateEbitda),
+      visuallyHiddenText = None,
+      (controllers.checkTotals.routes.ReviewTaxEBITDAController.onPageLoad(),messages("site.review"))))
+
     val aggregateNetTaxInterest = if(derivedData.aggregateInterest>=0){
-      Some(summaryListRow(messages("derivedCompany.t3-income"),currencyFormat(derivedData.aggregateInterest),
+      Some(summaryListRow(
+        messages("derivedCompany.t3-income"),
+        currencyFormat(derivedData.aggregateInterest),
+        visuallyHiddenText = None,
         (controllers.checkTotals.routes.ReviewNetTaxInterestController.onPageLoad(),messages("site.review"))))
     } else {
-      Some(summaryListRow(messages("derivedCompany.t3-expense"),currencyFormat(derivedData.aggregateInterest.abs),
+      Some(summaryListRow(
+        messages("derivedCompany.t3-expense"),
+        currencyFormat(derivedData.aggregateInterest.abs),
+        visuallyHiddenText = None,
         (controllers.checkTotals.routes.ReviewNetTaxInterestController.onPageLoad(),messages("site.review"))))
     }
     val aggregateAllocatedRestrictions = derivedData.restrictions match {
-      case Some(r) => Some(summaryListRow(messages("derivedCompany.t4"),
-        currencyFormat(r),(controllers.routes.UnderConstructionController.onPageLoad(),messages("site.review"))))
+      case Some(r) => Some(summaryListRow(
+        messages("derivedCompany.t4"),
+        currencyFormat(r),
+        visuallyHiddenText = None,
+        (controllers.routes.UnderConstructionController.onPageLoad(),messages("site.review"))))
       case None => None
     }
     val aggregateAllocatedReactivations = derivedData.reactivations match {
-      case Some(r) => Some(summaryListRow(messages("derivedCompany.t5"),
-        currencyFormat(r),(controllers.checkTotals.routes.ReviewReactivationsController.onPageLoad(),messages("site.review"))))
+      case Some(r) => Some(summaryListRow(
+        messages("derivedCompany.t5"),
+        currencyFormat(r),
+        visuallyHiddenText = None,
+        (controllers.checkTotals.routes.ReviewReactivationsController.onPageLoad(),messages("site.review"))))
       case None => None
     }
     Seq(numberOfUkCompanies,aggregateTaxEBITDA,aggregateNetTaxInterest,aggregateAllocatedRestrictions,aggregateAllocatedReactivations).flatten

--- a/app/utils/CheckYourAnswersAboutReturnCompanyHelper.scala
+++ b/app/utils/CheckYourAnswersAboutReturnCompanyHelper.scala
@@ -50,6 +50,7 @@ class CheckYourAnswersAboutReturnCompanyHelper(val userAnswers: UserAnswers)
       summaryListRow(
         label = messages("accountingPeriod.start.checkYourAnswersLabel", Seq()),
         value = accountingPage.startDate,
+        visuallyHiddenText = None,
         (aboutReturnRoutes.AccountingPeriodController.onPageLoad(CheckMode), messages("site.edit"))
       )
     }
@@ -60,6 +61,7 @@ class CheckYourAnswersAboutReturnCompanyHelper(val userAnswers: UserAnswers)
       summaryListRow(
         label = messages("accountingPeriod.end.checkYourAnswersLabel", Seq()),
         value = accountingPage.endDate,
+        visuallyHiddenText = None,
         (aboutReturnRoutes.AccountingPeriodController.onPageLoad(CheckMode), messages("site.edit"))
       )
     }

--- a/app/utils/CheckYourAnswersElectionsHelper.scala
+++ b/app/utils/CheckYourAnswersElectionsHelper.scala
@@ -59,6 +59,7 @@ class CheckYourAnswersElectionsHelper(val userAnswers: UserAnswers)
       Some(summaryListRow(
         Messages("investorGroupsAdded.checkYourAnswers.label"),
         Messages(s"investorGroupsAdded.checkYourAnswers.value.$valueMsgSuffix", numberOfInvestorGroupsAdded),
+        visuallyHiddenText = None,
         electionsRoutes.InvestorGroupsReviewAnswersListController.onPageLoad() -> Messages("investorGroupsAdded.checkYourAnswers.review")
       ))
     }
@@ -73,6 +74,7 @@ class CheckYourAnswersElectionsHelper(val userAnswers: UserAnswers)
       Some(summaryListRow(
         Messages("consolidatedPartnershipsAdded.checkYourAnswers.label"),
         Messages(s"consolidatedPartnershipsAdded.checkYourAnswers.value.$valueMsgSuffix", numberOfPartnershipsAdded),
+        visuallyHiddenText = None,
         electionsRoutes.PartnershipsReviewAnswersListController.onPageLoad() -> Messages("consolidatedPartnershipsAdded.checkYourAnswers.review")
       ))
     }
@@ -85,6 +87,7 @@ class CheckYourAnswersElectionsHelper(val userAnswers: UserAnswers)
       Some(summaryListRow(
         Messages("nonConsolidatedInvestmentsAdded.checkYourAnswers.label"),
         Messages(s"nonConsolidatedInvestmentsAdded.checkYourAnswers.value.$valueMsgSuffix", numberOfInvestmentsAdded),
+        visuallyHiddenText = None,
         electionsRoutes.InvestmentsReviewAnswersListController.onPageLoad() -> Messages("nonConsolidatedInvestmentsAdded.checkYourAnswers.review")
       ))
     }

--- a/app/utils/CheckYourAnswersHelper.scala
+++ b/app/utils/CheckYourAnswersHelper.scala
@@ -40,6 +40,7 @@ trait CheckYourAnswersHelper extends ImplicitDateFormatter with SummaryListRowHe
       summaryListRow(
         label = messages(s"$page.checkYourAnswersLabel", headingMessageArgs: _*),
         value = if (answerIsMsgKey) messages(s"$page.$ans") else ans,
+        visuallyHiddenText = None,
         changeLinkCall -> messages("site.edit")
       )
     }
@@ -55,6 +56,7 @@ trait CheckYourAnswersHelper extends ImplicitDateFormatter with SummaryListRowHe
       summaryListRowWideKey(
         label = messages(s"$page.checkYourAnswersLabel", headingMessageArgs: _*),
         value = if (answerIsMsgKey) messages(s"$page.$ans") else ans,
+        visuallyHiddenText = None,
         changeLinkCall -> messages("site.edit")
       )
     }
@@ -68,6 +70,7 @@ trait CheckYourAnswersHelper extends ImplicitDateFormatter with SummaryListRowHe
       summaryListRow(
         label = messages(s"$page.checkYourAnswersLabel", headingMessageArgs: _*),
         value = currencyFormat(ans),
+        visuallyHiddenText = None,
         changeLinkCall -> messages("site.edit")
       )
     }
@@ -81,6 +84,7 @@ trait CheckYourAnswersHelper extends ImplicitDateFormatter with SummaryListRowHe
       summaryListRow(
         label = messages(s"$page.checkYourAnswersLabel", headingMessageArgs: _*),
         value = s"$ans%",
+        visuallyHiddenText = None,
         changeLinkCall -> messages("site.edit")
       )
     }

--- a/app/utils/CheckYourAnswersUkCompanyHelper.scala
+++ b/app/utils/CheckYourAnswersUkCompanyHelper.scala
@@ -43,6 +43,7 @@ class CheckYourAnswersUkCompanyHelper(val userAnswers: UserAnswers)
     summaryListRow(
       label = messages("companyDetails.companyName.checkYourAnswersLabel", Seq()),
       value = companyName,
+      visuallyHiddenText = None,
       (ukCompanyRoutes.CompanyDetailsController.onPageLoad(idx, CheckMode), messages("site.edit"))
     )
   )
@@ -51,6 +52,7 @@ class CheckYourAnswersUkCompanyHelper(val userAnswers: UserAnswers)
       summaryListRow(
         label = messages("companyDetails.ctutr.checkYourAnswersLabel", Seq()),
         value = ctutr,
+        visuallyHiddenText = None,
         (ukCompanyRoutes.CompanyDetailsController.onPageLoad(idx, CheckMode), messages("site.edit"))
       )
     )
@@ -69,6 +71,7 @@ class CheckYourAnswersUkCompanyHelper(val userAnswers: UserAnswers)
       summaryListRow(
         label = messages("enterCompanyTaxEBITDA.checkYourAnswersLabel", Seq()),
         value = currencyFormat(taxEBITDA),
+        visuallyHiddenText = None,
         (ukCompanyRoutes.EnterCompanyTaxEBITDAController.onPageLoad(idx, CheckMode), messages("site.edit"))
       )
     ))
@@ -78,6 +81,7 @@ class CheckYourAnswersUkCompanyHelper(val userAnswers: UserAnswers)
       summaryListRow(
         label = messages("netTaxInterestAmount.checkYourAnswersLabel", Seq()),
         value = s"${currencyFormat(netTaxInterest)} ${incomeOrExpense(idx)}",
+        visuallyHiddenText = None,
         (ukCompanyRoutes.NetTaxInterestAmountController.onPageLoad(idx, CheckMode), messages("site.edit"))
       )
     ))
@@ -87,6 +91,7 @@ class CheckYourAnswersUkCompanyHelper(val userAnswers: UserAnswers)
       summaryListRow(
         label = messages("reactivationAmount.checkYourAnswersLabel", Seq()),
         value = currencyFormat(reactivationModel.reactivation),
+        visuallyHiddenText = None,
         (ukCompanyRoutes.ReactivationAmountController.onPageLoad(idx, CheckMode), messages("site.edit"))
       )
     ))
@@ -111,6 +116,7 @@ class CheckYourAnswersUkCompanyHelper(val userAnswers: UserAnswers)
     summaryListRow(
       label = messages(s"$page.checkYourAnswersLabel", headingMessageArgs: _*),
       value = if (answerIsMsgKey) messages(s"$page.$value") else value,
+      visuallyHiddenText = None,
       changeLinkCall -> messages("site.edit")
     )
 }

--- a/app/utils/CheckYourAnswersUltimateParentCompanyHelper.scala
+++ b/app/utils/CheckYourAnswersUltimateParentCompanyHelper.scala
@@ -110,6 +110,7 @@ class CheckYourAnswersUltimateParentCompanyHelper(val userAnswers: UserAnswers)
     summaryListRowWideKey(
       label = messages(s"$page.checkYourAnswersLabel", headingMessageArgs: _*),
       value = if (answerIsMsgKey) messages(s"$page.$value") else value,
+      visuallyHiddenText = None,
       changeLinkCall -> messages("site.edit")
     )
 }

--- a/app/utils/DeemedParentReviewAnswersListHelper.scala
+++ b/app/utils/DeemedParentReviewAnswersListHelper.scala
@@ -28,6 +28,7 @@ class DeemedParentReviewAnswersListHelper(val userAnswers: UserAnswers)
     case (model, idx) => summaryListRow(
       model.companyName.name,
       model.utr.fold("")(_.utr),
+      visuallyHiddenText = None,
       controllers.ultimateParentCompany.routes.CheckAnswersGroupStructureController.onPageLoad(idx + 1) -> messages("site.review"),
       controllers.ultimateParentCompany.routes.DeletionConfirmationController.onPageLoad(idx + 1) -> messages("site.delete")
     )

--- a/app/utils/InvestmentsReviewAnswersListHelper.scala
+++ b/app/utils/InvestmentsReviewAnswersListHelper.scala
@@ -28,6 +28,7 @@ class InvestmentsReviewAnswersListHelper(val userAnswers: UserAnswers)
     case (name, idx) => summaryListRow(
       name,
       "",
+      visuallyHiddenText = None,
       controllers.elections.routes.InvestmentNameController.onPageLoad(idx + 1, CheckMode) -> messages("site.edit"),
       controllers.elections.routes.InvestmentsDeletionConfirmationController.onPageLoad(idx + 1) -> messages("site.delete")
     )

--- a/app/utils/InvestorGroupsReviewAnswersListHelper.scala
+++ b/app/utils/InvestorGroupsReviewAnswersListHelper.scala
@@ -28,6 +28,7 @@ class InvestorGroupsReviewAnswersListHelper(val userAnswers: UserAnswers)
     case (model, idx) => summaryListRowWideKey(
       model.investorName,
       "",
+      visuallyHiddenText = None,
       controllers.elections.routes.InvestorGroupNameController.onPageLoad(idx + 1, NormalMode) -> messages("site.edit"),
       controllers.elections.routes.InvestorGroupsDeletionConfirmationController.onPageLoad(idx + 1) -> messages("site.delete")
     )

--- a/app/utils/PartnershipsReviewAnswersListHelper.scala
+++ b/app/utils/PartnershipsReviewAnswersListHelper.scala
@@ -28,6 +28,7 @@ class PartnershipsReviewAnswersListHelper(val userAnswers: UserAnswers)
     case (partnership, idx) => summaryListRow(
       partnership.name,
       value = "",
+      visuallyHiddenText = None,
       controllers.elections.routes.PartnershipNameController.onPageLoad(idx + 1, NormalMode) -> messages("site.edit"),
       controllers.elections.routes.PartnershipDeletionConfirmationController.onPageLoad(idx + 1) -> messages("site.delete")
     )

--- a/app/utils/ReviewNetTaxInterestHelper.scala
+++ b/app/utils/ReviewNetTaxInterestHelper.scala
@@ -33,6 +33,7 @@ class ReviewNetTaxInterestHelper(val userAnswers: UserAnswers)
         summaryListRow(
           label = model.companyDetails.companyName,
           value = s"${currencyFormat(amount)} ${messages(s"reviewNetTaxInterest.checkYourAnswers.$incomeOrExpense")}",
+          visuallyHiddenText = None,
           actions = controllers.ukCompanies.routes.NetTaxInterestAmountController.onPageLoad(idx + 1, ReviewMode) -> messages("site.edit")
         )
       }

--- a/app/utils/ReviewReactivationsHelper.scala
+++ b/app/utils/ReviewReactivationsHelper.scala
@@ -33,6 +33,7 @@ class ReviewReactivationsHelper(val userAnswers: UserAnswers)
         summaryListRow(
           label = model.companyDetails.companyName,
           value = currencyFormat(amount),
+          visuallyHiddenText = None,
           actions = controllers.ukCompanies.routes.ReactivationAmountController.onPageLoad(idx + 1, ReviewMode) -> messages("site.edit")
         )
       }

--- a/app/utils/ReviewTaxEBITDARowsHelper.scala
+++ b/app/utils/ReviewTaxEBITDARowsHelper.scala
@@ -29,6 +29,7 @@ class ReviewTaxEBITDARowsHelper(val userAnswers: UserAnswers)
         summaryListRow(
           model.companyDetails.companyName,
           currencyFormat(ebitda),
+          visuallyHiddenText = None,
           controllers.ukCompanies.routes.EnterCompanyTaxEBITDAController.onPageLoad(idx + 1, ReviewMode) -> messages("site.edit")
       )
     }

--- a/app/utils/UkCompaniesReviewAnswersListHelper.scala
+++ b/app/utils/UkCompaniesReviewAnswersListHelper.scala
@@ -28,6 +28,7 @@ class UkCompaniesReviewAnswersListHelper(val userAnswers: UserAnswers)
     case (model, idx) => summaryListRow(
       model.companyDetails.companyName,
       model.companyDetails.ctutr,
+      visuallyHiddenText = None,
       controllers.ukCompanies.routes.CheckAnswersUkCompanyController.onPageLoad(idx + 1) -> messages("site.review"),
       controllers.ukCompanies.routes.UkCompaniesDeletionConfirmationController.onPageLoad(idx + 1) -> messages("site.delete")
     )

--- a/app/viewmodels/SummaryListRowHelper.scala
+++ b/app/viewmodels/SummaryListRowHelper.scala
@@ -22,15 +22,15 @@ import uk.gov.hmrc.govukfrontend.views.viewmodels.summarylist._
 
 trait SummaryListRowHelper {
 
-  def summaryListRow(label: String, value: String, actions: (Call, String)*): SummaryListRow = {
-    summaryListRowSpecifyingClass(label, value, "govuk-!-width-one-third", actions: _*)
+  def summaryListRow(label: String, value: String, visuallyHiddenText: Option[String], actions: (Call, String)*): SummaryListRow = {
+    summaryListRowSpecifyingClass(label, value, "govuk-!-width-one-third", visuallyHiddenText, actions: _*)
   }
 
-  def summaryListRowWideKey(label: String, value: String, actions: (Call, String)*): SummaryListRow = {
-    summaryListRowSpecifyingClass(label, value, "govuk-!-width-two-thirds", actions: _*)
+  def summaryListRowWideKey(label: String, value: String, visuallyHiddenText: Option[String], actions: (Call, String)*): SummaryListRow = {
+    summaryListRowSpecifyingClass(label, value, "govuk-!-width-two-thirds", visuallyHiddenText, actions: _*)
   }
 
-  private def summaryListRowSpecifyingClass(label: String, value: String, keyClass: String, actions: (Call, String)*): SummaryListRow = {
+  private def summaryListRowSpecifyingClass(label: String, value: String, keyClass: String, visuallyHiddenText: Option[String], actions: (Call, String)*): SummaryListRow = {
     SummaryListRow(
       key = Key(
         content = Text(label),
@@ -43,10 +43,18 @@ trait SummaryListRowHelper {
       actions = Some(Actions(
         items = actions.map { case (call, linkText) => ActionItem(
           href = call.url,
-          content = Text(linkText)
+          content = Text(linkText),
+          visuallyHiddenText = Some(defaultVisuallyHiddenText(label, visuallyHiddenText))
         )},
         classes = "govuk-!-width-one-third")
       )
     )
   }
+
+  def defaultVisuallyHiddenText(label: String, visuallyHiddenText: Option[String]): String = 
+    visuallyHiddenText match {
+      case Some(text) => text
+      case None => label
+    }
+
 }

--- a/test/utils/CheckTotalsHelperSpec.scala
+++ b/test/utils/CheckTotalsHelperSpec.scala
@@ -146,26 +146,31 @@ class CheckTotalsHelperSpec extends SpecBase with BaseConstants with SummaryList
           summaryListRow(
             CheckTotalsMessages.t1,
             "1",
+            visuallyHiddenText = None,
             controllers.ukCompanies.routes.UkCompaniesReviewAnswersListController.onPageLoad() -> BaseMessages.review
           ),
           summaryListRow(
             CheckTotalsMessages.t2,
             currencyFormat(taxEBITDA),
+            visuallyHiddenText = None,
             controllers.checkTotals.routes.ReviewTaxEBITDAController.onPageLoad() -> BaseMessages.review
           ),
           summaryListRow(
             CheckTotalsMessages.t3Expense,
             currencyFormat(netTaxInterestExpense),
+            visuallyHiddenText = None,
             controllers.checkTotals.routes.ReviewNetTaxInterestController.onPageLoad() -> BaseMessages.review
           ),
           summaryListRow(
             CheckTotalsMessages.t4,
             currencyFormat(totalDisallowances),
+            visuallyHiddenText = None,
             controllers.routes.UnderConstructionController.onPageLoad() -> BaseMessages.review
           ),
           summaryListRow(
             CheckTotalsMessages.t5,
             currencyFormat(reactivation),
+            visuallyHiddenText = None,
             controllers.checkTotals.routes.ReviewReactivationsController.onPageLoad() -> BaseMessages.review
           )
         )

--- a/test/utils/CheckYourAnswersAboutReturnCompanyHelperSpec.scala
+++ b/test/utils/CheckYourAnswersAboutReturnCompanyHelperSpec.scala
@@ -50,51 +50,61 @@ class CheckYourAnswersAboutReturnCompanyHelperSpec extends SpecBase with BaseCon
   val expectedReportingCompanyAppointed = summaryListRow(
     messages("reportingCompanyAppointed.checkYourAnswersLabel"),
     "Yes",
+    visuallyHiddenText = None,
     aboutReturnRoutes.ReportingCompanyAppointedController.onPageLoad(CheckMode) -> BaseMessages.changeLink
   )
   val expectedAgentActingOnBehalfOfCompany = summaryListRow(
     messages("agentActingOnBehalfOfCompany.checkYourAnswersLabel"),
     "Yes",
+    visuallyHiddenText = None,
     aboutReturnRoutes.AgentActingOnBehalfOfCompanyController.onPageLoad(CheckMode) -> BaseMessages.changeLink
   )
   val expectedAgentName = summaryListRow(
     messages("agentName.checkYourAnswersLabel"),
     agentName,
+    visuallyHiddenText = None,
     aboutReturnRoutes.AgentNameController.onPageLoad(CheckMode) -> BaseMessages.changeLink
   )
   val expectedFullOrAbbreviatedReturn = summaryListRow(
     messages("fullOrAbbreviatedReturn.checkYourAnswersLabel"),
     messages("fullOrAbbreviatedReturn.full"),
+    visuallyHiddenText = None,
     aboutReturnRoutes.FullOrAbbreviatedReturnController.onPageLoad(CheckMode) -> BaseMessages.changeLink
   )
   val expectedRevisingReturn = summaryListRow(
     CheckAnswersAboutReturnMessages.revisingReturn,
     BaseMessages.yes,
+    visuallyHiddenText = None,
     aboutReturnRoutes.RevisingReturnController.onPageLoad(CheckMode) -> BaseMessages.changeLink
   )
   val expectedWhatHasChanged = summaryListRow(
     messages("tellUsWhatHasChanged.checkYourAnswersLabel"),
     "Something has changed",
+    visuallyHiddenText = None,
     aboutReturnRoutes.TellUsWhatHasChangedController.onPageLoad(CheckMode) -> BaseMessages.changeLink
   )
   val expectedReportingCompanyName = summaryListRow(
     messages("reportingCompanyName.checkYourAnswersLabel"),
     companyNameModel.name,
+    visuallyHiddenText = None,
     aboutReturnRoutes.ReportingCompanyNameController.onPageLoad(CheckMode) -> BaseMessages.changeLink
   )
   val expectedReportingCompanyCTUTR = summaryListRow(
     messages("reportingCompanyCTUTR.checkYourAnswersLabel"),
     ctutrModel.utr,
+    visuallyHiddenText = None,
     aboutReturnRoutes.ReportingCompanyCTUTRController.onPageLoad(CheckMode) -> BaseMessages.changeLink
   )
   val expectedAccountingPeriodStart = summaryListRow(
     messages("accountingPeriod.start.checkYourAnswersLabel"),
     "1 January 2020",
+    visuallyHiddenText = None,
     aboutReturnRoutes.AccountingPeriodController.onPageLoad(CheckMode) -> BaseMessages.changeLink
   )
   val expectedAccountingPeriodEnd = summaryListRow(
     messages("accountingPeriod.end.checkYourAnswersLabel"),
     "1 February 2020",
+    visuallyHiddenText = None,
     aboutReturnRoutes.AccountingPeriodController.onPageLoad(CheckMode) -> BaseMessages.changeLink
   )
 
@@ -197,6 +207,7 @@ class CheckYourAnswersAboutReturnCompanyHelperSpec extends SpecBase with BaseCon
         summaryListRow(
           CheckAnswersAboutReturnMessages.revisingReturn,
           BaseMessages.no,
+          visuallyHiddenText = None,
           aboutReturnRoutes.RevisingReturnController.onPageLoad(CheckMode) -> BaseMessages.changeLink
         ),
         expectedReportingCompanyName,

--- a/test/utils/CheckYourAnswersElectionsHelperSpec.scala
+++ b/test/utils/CheckYourAnswersElectionsHelperSpec.scala
@@ -55,6 +55,7 @@ class CheckYourAnswersElectionsHelperSpec extends SpecBase with BaseConstants wi
         helper.groupRatioElection mustBe Some(summaryListRow(
           messages("groupRatioElection.checkYourAnswersLabel"),
           BaseMessages.yes,
+          visuallyHiddenText = None,
           electionsRoutes.GroupRatioElectionController.onPageLoad(CheckMode) -> BaseMessages.changeLink
         ))
       }
@@ -67,6 +68,7 @@ class CheckYourAnswersElectionsHelperSpec extends SpecBase with BaseConstants wi
         helper.groupRatioBlendedElection mustBe Some(summaryListRow(
           CheckAnswersElectionsMessages.groupRatioBlended,
           BaseMessages.yes,
+          visuallyHiddenText = None,
           electionsRoutes.GroupRatioBlendedElectionController.onPageLoad(CheckMode) -> BaseMessages.changeLink
         ))
       }
@@ -79,6 +81,7 @@ class CheckYourAnswersElectionsHelperSpec extends SpecBase with BaseConstants wi
         helper.investorGroupsRow mustBe Some(summaryListRow(
           CheckAnswersElectionsMessages.investorGroupsHeading,
           CheckAnswersElectionsMessages.investorGroupsValue(1),
+          visuallyHiddenText = None,
           electionsRoutes.InvestorGroupsReviewAnswersListController.onPageLoad() -> CheckAnswersElectionsMessages.investorGroupsReview
         ))
       }
@@ -92,6 +95,7 @@ class CheckYourAnswersElectionsHelperSpec extends SpecBase with BaseConstants wi
         helper.investorGroupsRow mustBe Some(summaryListRow(
           CheckAnswersElectionsMessages.investorGroupsHeading,
           CheckAnswersElectionsMessages.investorGroupsValue(3),
+          visuallyHiddenText = None,
           electionsRoutes.InvestorGroupsReviewAnswersListController.onPageLoad() -> CheckAnswersElectionsMessages.investorGroupsReview
         ))
       }
@@ -104,6 +108,7 @@ class CheckYourAnswersElectionsHelperSpec extends SpecBase with BaseConstants wi
         helper.electedGroupEBITDABefore mustBe Some(summaryListRow(
           CheckAnswersElectionsMessages.electedGroupEBITDABefore,
           BaseMessages.no,
+          visuallyHiddenText = None,
           electionsRoutes.ElectedGroupEBITDABeforeController.onPageLoad(CheckMode) -> BaseMessages.changeLink
         ))
       }
@@ -116,6 +121,7 @@ class CheckYourAnswersElectionsHelperSpec extends SpecBase with BaseConstants wi
         helper.groupEBITDAChargeableGainsElection mustBe Some(summaryListRow(
           CheckAnswersElectionsMessages.groupEBITDAElection,
           BaseMessages.yes,
+          visuallyHiddenText = None,
           electionsRoutes.GroupEBITDAChargeableGainsElectionController.onPageLoad(CheckMode) -> BaseMessages.changeLink
         ))
       }
@@ -128,6 +134,7 @@ class CheckYourAnswersElectionsHelperSpec extends SpecBase with BaseConstants wi
         helper.electedInterestAllowanceAlternativeCalcBefore mustBe Some(summaryListRow(
           CheckAnswersElectionsMessages.electedInterestAllowanceAlternativeCalcBefore,
           BaseMessages.no,
+          visuallyHiddenText = None,
           electionsRoutes.ElectedInterestAllowanceAlternativeCalcBeforeController.onPageLoad(CheckMode) -> BaseMessages.changeLink
         ))
       }
@@ -140,6 +147,7 @@ class CheckYourAnswersElectionsHelperSpec extends SpecBase with BaseConstants wi
         helper.interestAllowanceAlternativeCalcElection mustBe Some(summaryListRow(
           CheckAnswersElectionsMessages.interestAllowanceAlternativeCalcElection,
           BaseMessages.yes,
+          visuallyHiddenText = None,
           electionsRoutes.InterestAllowanceAlternativeCalcElectionController.onPageLoad(CheckMode) -> BaseMessages.changeLink
         ))
       }
@@ -152,6 +160,7 @@ class CheckYourAnswersElectionsHelperSpec extends SpecBase with BaseConstants wi
         helper.interestAllowanceNonConsolidatedInvestmentsElection mustBe Some(summaryListRow(
           CheckAnswersElectionsMessages.interestAllowanceNonConsolidatedElection,
           BaseMessages.yes,
+          visuallyHiddenText = None,
           electionsRoutes.InterestAllowanceNonConsolidatedInvestmentsElectionController.onPageLoad(CheckMode) -> BaseMessages.changeLink
         ))
       }
@@ -164,6 +173,7 @@ class CheckYourAnswersElectionsHelperSpec extends SpecBase with BaseConstants wi
         helper.nonConsolidatedInvestmentsRow mustBe Some(summaryListRow(
           CheckAnswersElectionsMessages.nonConsolidatedInvestmentsHeading,
           CheckAnswersElectionsMessages.nonConsolidatedInvestmentsValue(1),
+          visuallyHiddenText = None,
           electionsRoutes.InvestmentsReviewAnswersListController.onPageLoad() -> CheckAnswersElectionsMessages.nonConsolidatedInvestmentsReview
         ))
       }
@@ -177,6 +187,7 @@ class CheckYourAnswersElectionsHelperSpec extends SpecBase with BaseConstants wi
         helper.nonConsolidatedInvestmentsRow mustBe Some(summaryListRow(
           CheckAnswersElectionsMessages.nonConsolidatedInvestmentsHeading,
           CheckAnswersElectionsMessages.nonConsolidatedInvestmentsValue(3),
+          visuallyHiddenText = None,
           electionsRoutes.InvestmentsReviewAnswersListController.onPageLoad() -> CheckAnswersElectionsMessages.nonConsolidatedInvestmentsReview
         ))
       }
@@ -189,6 +200,7 @@ class CheckYourAnswersElectionsHelperSpec extends SpecBase with BaseConstants wi
         helper.electedInterestAllowanceConsolidatedPshipBefore mustBe Some(summaryListRow(
           CheckAnswersElectionsMessages.electedInterestAllowanceConsolidatedPshipBefore,
           BaseMessages.no,
+          visuallyHiddenText = None,
           electionsRoutes.ElectedInterestAllowanceConsolidatedPshipBeforeController.onPageLoad(CheckMode) -> BaseMessages.changeLink
         ))
       }
@@ -201,6 +213,7 @@ class CheckYourAnswersElectionsHelperSpec extends SpecBase with BaseConstants wi
         helper.interestAllowanceConsolidatedPshipElection mustBe Some(summaryListRow(
           CheckAnswersElectionsMessages.interestAllowanceConsolidatedPshipElection,
           BaseMessages.yes,
+          visuallyHiddenText = None,
           electionsRoutes.InterestAllowanceConsolidatedPshipElectionController.onPageLoad(CheckMode) -> BaseMessages.changeLink
         ))
       }
@@ -213,6 +226,7 @@ class CheckYourAnswersElectionsHelperSpec extends SpecBase with BaseConstants wi
         helper.consolidatedPartnershipsRow mustBe Some(summaryListRow(
           CheckAnswersElectionsMessages.consolidatedPartnershipsHeading,
           CheckAnswersElectionsMessages.consolidatedPartnershipsValue(1),
+          visuallyHiddenText = None,
           electionsRoutes.PartnershipsReviewAnswersListController.onPageLoad() -> CheckAnswersElectionsMessages.consolidatedPartnershipsReview
         ))
       }
@@ -226,6 +240,7 @@ class CheckYourAnswersElectionsHelperSpec extends SpecBase with BaseConstants wi
         helper.consolidatedPartnershipsRow mustBe Some(summaryListRow(
           CheckAnswersElectionsMessages.consolidatedPartnershipsHeading,
           CheckAnswersElectionsMessages.consolidatedPartnershipsValue(3),
+          visuallyHiddenText = None,
           electionsRoutes.PartnershipsReviewAnswersListController.onPageLoad() -> CheckAnswersElectionsMessages.consolidatedPartnershipsReview
         ))
       }

--- a/test/utils/CheckYourAnswersGroupLevelInformationHelperSpec.scala
+++ b/test/utils/CheckYourAnswersGroupLevelInformationHelperSpec.scala
@@ -51,6 +51,7 @@ class CheckYourAnswersGroupLevelInformationHelperSpec extends SpecBase with Base
         helper.groupSubjectToRestrictions mustBe Some(summaryListRow(
           CheckAnswersGroupLevelInformationMessages.groupSubjectToRestrictions,
           BaseMessages.yes,
+          visuallyHiddenText = None,
           groupLevelInformationRoutes.GroupSubjectToRestrictionsController.onPageLoad(CheckMode) -> BaseMessages.changeLink
         ))
       }
@@ -63,6 +64,7 @@ class CheckYourAnswersGroupLevelInformationHelperSpec extends SpecBase with Base
         helper.groupSubjectToReactivations mustBe Some(summaryListRow(
           CheckAnswersGroupLevelInformationMessages.groupSubjectToReactivations,
           BaseMessages.no,
+          visuallyHiddenText = None,
           groupLevelInformationRoutes.GroupSubjectToReactivationsController.onPageLoad(CheckMode) -> BaseMessages.changeLink
         ))
       }
@@ -75,6 +77,7 @@ class CheckYourAnswersGroupLevelInformationHelperSpec extends SpecBase with Base
         helper.interestReactivationsCap mustBe Some(summaryListRow(
           CheckAnswersGroupLevelInformationMessages.interestReactivationsCap,
           currencyFormat(interestReactivationCap),
+          visuallyHiddenText = None,
           groupLevelInformationRoutes.InterestReactivationsCapController.onPageLoad(CheckMode) -> BaseMessages.changeLink
         ))
       }
@@ -87,6 +90,7 @@ class CheckYourAnswersGroupLevelInformationHelperSpec extends SpecBase with Base
         helper.interestAllowanceBroughtForward mustBe Some(summaryListRow(
           CheckAnswersGroupLevelInformationMessages.interestAllowanceBroughtForward,
           currencyFormat(interestAllowanceBroughtForward),
+          visuallyHiddenText = None,
           groupLevelInformationRoutes.InterestAllowanceBroughtForwardController.onPageLoad(CheckMode) -> BaseMessages.changeLink
         ))
       }
@@ -99,6 +103,7 @@ class CheckYourAnswersGroupLevelInformationHelperSpec extends SpecBase with Base
         helper.groupInterestAllowance mustBe Some(summaryListRow(
           CheckAnswersGroupLevelInformationMessages.groupInterestAllowance,
           currencyFormat(groupInterestAllowance),
+          visuallyHiddenText = None,
           groupLevelInformationRoutes.GroupInterestAllowanceController.onPageLoad(CheckMode) -> BaseMessages.changeLink
         ))
       }
@@ -111,6 +116,7 @@ class CheckYourAnswersGroupLevelInformationHelperSpec extends SpecBase with Base
         helper.groupInterestCapacity mustBe Some(summaryListRow(
           CheckAnswersGroupLevelInformationMessages.groupInterestCapacity,
           currencyFormat(groupInterestCapacity),
+          visuallyHiddenText = None,
           groupLevelInformationRoutes.GroupInterestCapacityController.onPageLoad(CheckMode) -> BaseMessages.changeLink
         ))
       }
@@ -123,6 +129,7 @@ class CheckYourAnswersGroupLevelInformationHelperSpec extends SpecBase with Base
         helper.angie mustBe Some(summaryListRow(
           CheckAnswersGroupLevelInformationMessages.angie,
           currencyFormat(angie),
+          visuallyHiddenText = None,
           groupLevelInformationRoutes.EnterANGIEController.onPageLoad(CheckMode) -> BaseMessages.changeLink
         ))
       }
@@ -135,6 +142,7 @@ class CheckYourAnswersGroupLevelInformationHelperSpec extends SpecBase with Base
         helper.qngie mustBe Some(summaryListRow(
           CheckAnswersGroupLevelInformationMessages.qngie,
           currencyFormat(qngie),
+          visuallyHiddenText = None,
           groupLevelInformationRoutes.EnterQNGIEController.onPageLoad(CheckMode) -> BaseMessages.changeLink
         ))
       }
@@ -147,6 +155,7 @@ class CheckYourAnswersGroupLevelInformationHelperSpec extends SpecBase with Base
         helper.groupEBITDA mustBe Some(summaryListRow(
           CheckAnswersGroupLevelInformationMessages.groupEBITDA,
           currencyFormat(ebitda),
+          visuallyHiddenText = None,
           groupLevelInformationRoutes.GroupEBITDAController.onPageLoad(CheckMode) -> BaseMessages.changeLink
         ))
       }
@@ -159,6 +168,7 @@ class CheckYourAnswersGroupLevelInformationHelperSpec extends SpecBase with Base
         helper.disallowedAmount mustBe Some(summaryListRow(
           CheckAnswersGroupLevelInformationMessages.disallowedAmount,
           currencyFormat(disallowedAmount),
+          visuallyHiddenText = None,
           groupLevelInformationRoutes.DisallowedAmountController.onPageLoad(CheckMode) -> BaseMessages.changeLink
         ))
       }
@@ -171,6 +181,7 @@ class CheckYourAnswersGroupLevelInformationHelperSpec extends SpecBase with Base
         helper.groupRatioPercentage mustBe Some(summaryListRow(
           CheckAnswersGroupLevelInformationMessages.groupRatioPercentage,
           groupRatioPercentage.toString,
+          visuallyHiddenText = None,
           groupLevelInformationRoutes.GroupRatioPercentageController.onPageLoad(CheckMode) -> BaseMessages.changeLink
         ))
       }
@@ -183,6 +194,7 @@ class CheckYourAnswersGroupLevelInformationHelperSpec extends SpecBase with Base
         helper.returnContainEstimates mustBe Some(summaryListRow(
           CheckAnswersGroupLevelInformationMessages.returnContainEstimates,
           BaseMessages.no,
+          visuallyHiddenText = None,
           groupLevelInformationRoutes.ReturnContainEstimatesController.onPageLoad(CheckMode) -> BaseMessages.changeLink
         ))
       }

--- a/test/utils/CheckYourAnswersUkCompaniesHelperSpec.scala
+++ b/test/utils/CheckYourAnswersUkCompaniesHelperSpec.scala
@@ -42,6 +42,7 @@ class CheckYourAnswersUkCompaniesHelperSpec extends SpecBase with BaseConstants 
         helper.companyName(1) mustBe Some(summaryListRow(
           CheckAnswersUkCompanyMessages.companyName,
           companyNameModel.name,
+          visuallyHiddenText = None,
           ukCompaniesRoutes.CompanyDetailsController.onPageLoad(1, CheckMode) -> BaseMessages.changeLink
         ))
       }
@@ -54,6 +55,7 @@ class CheckYourAnswersUkCompaniesHelperSpec extends SpecBase with BaseConstants 
         helper.ctutr(1) mustBe Some(summaryListRow(
           CheckAnswersUkCompanyMessages.companyCTUTR,
           ctutrModel.utr,
+          visuallyHiddenText = None,
           ukCompaniesRoutes.CompanyDetailsController.onPageLoad(1, CheckMode) -> BaseMessages.changeLink
         ))
       }
@@ -66,6 +68,7 @@ class CheckYourAnswersUkCompaniesHelperSpec extends SpecBase with BaseConstants 
         helper.consentingCompany(1) mustBe Some(summaryListRow(
           CheckAnswersUkCompanyMessages.consenting,
           BaseMessages.yes,
+          visuallyHiddenText = None,
           ukCompaniesRoutes.ConsentingCompanyController.onPageLoad(1, CheckMode) -> BaseMessages.changeLink
         ))
       }
@@ -78,6 +81,7 @@ class CheckYourAnswersUkCompaniesHelperSpec extends SpecBase with BaseConstants 
         helper.enterCompanyTaxEBITDA(1) mustBe Some(summaryListRow(
           CheckAnswersUkCompanyMessages.taxEBITDA,
           currencyFormat(taxEBITDA),
+          visuallyHiddenText = None,
           ukCompaniesRoutes.EnterCompanyTaxEBITDAController.onPageLoad(1, CheckMode) -> BaseMessages.changeLink
         ))
       }
@@ -90,6 +94,7 @@ class CheckYourAnswersUkCompaniesHelperSpec extends SpecBase with BaseConstants 
         helper.netTaxInterestAmount(1) mustBe Some(summaryListRow(
           CheckAnswersUkCompanyMessages.netTaxInterest,
           currencyFormat(netTaxInterestIncome) + " Expense",
+          visuallyHiddenText = None,
           ukCompaniesRoutes.NetTaxInterestAmountController.onPageLoad(1, CheckMode) -> BaseMessages.changeLink
         ))
       }
@@ -102,6 +107,7 @@ class CheckYourAnswersUkCompaniesHelperSpec extends SpecBase with BaseConstants 
         helper.companyReactivationAmount(1) mustBe Some(summaryListRow(
           CheckAnswersUkCompanyMessages.reactivationAmount,
           currencyFormat(reactivation),
+          visuallyHiddenText = None,
           ukCompaniesRoutes.ReactivationAmountController.onPageLoad(1, CheckMode) -> BaseMessages.changeLink
         ))
       }

--- a/test/utils/CheckYourAnswersUltimateParentCompanyHelperSpec.scala
+++ b/test/utils/CheckYourAnswersUltimateParentCompanyHelperSpec.scala
@@ -43,6 +43,7 @@ class CheckYourAnswersUltimateParentCompanyHelperSpec extends SpecBase with Base
         helper.reportingCompanySameAsParent mustBe Some(summaryListRowWideKey(
           CheckAnswersUltimateParentCompanyMessages.reportingCompanySameAsParent,
           BaseMessages.no,
+          visuallyHiddenText = None,
           ultimateParentCompanyRoutes.ReportingCompanySameAsParentController.onPageLoad(CheckMode) -> BaseMessages.changeLink
         ))
       }
@@ -55,6 +56,7 @@ class CheckYourAnswersUltimateParentCompanyHelperSpec extends SpecBase with Base
         helper.deemedParent mustBe Some(summaryListRowWideKey(
           CheckAnswersUltimateParentCompanyMessages.deemedParent,
           BaseMessages.no,
+          visuallyHiddenText = None,
           ultimateParentCompanyRoutes.HasDeemedParentController.onPageLoad(CheckMode) -> BaseMessages.changeLink
         ))
       }
@@ -67,6 +69,7 @@ class CheckYourAnswersUltimateParentCompanyHelperSpec extends SpecBase with Base
         helper.parentCompanyName(1) mustBe Some(summaryListRowWideKey(
           CheckAnswersUltimateParentCompanyMessages.parentCompanyName,
           companyNameModel.name,
+          visuallyHiddenText = None,
           ultimateParentCompanyRoutes.ParentCompanyNameController.onPageLoad(1, CheckMode) -> BaseMessages.changeLink
         ))
       }
@@ -79,6 +82,7 @@ class CheckYourAnswersUltimateParentCompanyHelperSpec extends SpecBase with Base
         helper.payTaxInUk(1) mustBe Some(summaryListRowWideKey(
           CheckAnswersUltimateParentCompanyMessages.payTaxInUk,
           BaseMessages.yes,
+          visuallyHiddenText = None,
           ultimateParentCompanyRoutes.PayTaxInUkController.onPageLoad(1, CheckMode) -> BaseMessages.changeLink
         ))
       }
@@ -91,6 +95,7 @@ class CheckYourAnswersUltimateParentCompanyHelperSpec extends SpecBase with Base
         helper.limitedLiabilityPartnership(1) mustBe Some(summaryListRowWideKey(
           CheckAnswersUltimateParentCompanyMessages.limitedLiabilityPartnership,
           BaseMessages.yes,
+          visuallyHiddenText = None,
           ultimateParentCompanyRoutes.LimitedLiabilityPartnershipController.onPageLoad(1, CheckMode) -> BaseMessages.changeLink
         ))
       }
@@ -103,6 +108,7 @@ class CheckYourAnswersUltimateParentCompanyHelperSpec extends SpecBase with Base
         helper.parentCompanyCTUTR(1) mustBe Some(summaryListRowWideKey(
           CheckAnswersUltimateParentCompanyMessages.parentCompanyCTUTR,
           ctutrModel.utr,
+          visuallyHiddenText = None,
           ultimateParentCompanyRoutes.ParentCompanyCTUTRController.onPageLoad(1, CheckMode) -> BaseMessages.changeLink
         ))
       }
@@ -115,6 +121,7 @@ class CheckYourAnswersUltimateParentCompanyHelperSpec extends SpecBase with Base
         helper.parentCompanySAUTR(1) mustBe Some(summaryListRowWideKey(
           CheckAnswersUltimateParentCompanyMessages.parentCompanySAUTR,
           sautrModel.utr,
+          visuallyHiddenText = None,
           ultimateParentCompanyRoutes.ParentCompanySAUTRController.onPageLoad(1, CheckMode) -> BaseMessages.changeLink
         ))
       }
@@ -127,6 +134,7 @@ class CheckYourAnswersUltimateParentCompanyHelperSpec extends SpecBase with Base
         helper.countryOfIncorporation(1) mustBe Some(summaryListRowWideKey(
           CheckAnswersUltimateParentCompanyMessages.registeredCountry,
           nonUkCountryCode.country,
+          visuallyHiddenText = None,
           ultimateParentCompanyRoutes.CountryOfIncorporationController.onPageLoad(1, CheckMode) -> BaseMessages.changeLink
         ))
       }

--- a/test/utils/DeemedParentReviewAnswersListHelperSpec.scala
+++ b/test/utils/DeemedParentReviewAnswersListHelperSpec.scala
@@ -42,18 +42,21 @@ class DeemedParentReviewAnswersListHelperSpec extends SpecBase with SummaryListR
           summaryListRow(
             deemedParentModelUkCompany.companyName.name,
             deemedParentModelUkCompany.utr.get.utr,
+            visuallyHiddenText = None,
             controllers.ultimateParentCompany.routes.CheckAnswersGroupStructureController.onPageLoad(1) -> BaseMessages.review,
             controllers.ultimateParentCompany.routes.DeletionConfirmationController.onPageLoad(1) -> BaseMessages.delete
           ),
           summaryListRow(
             deemedParentModelUkPartnership.companyName.name,
             deemedParentModelUkPartnership.utr.get.utr,
+            visuallyHiddenText = None,
             controllers.ultimateParentCompany.routes.CheckAnswersGroupStructureController.onPageLoad(2) -> BaseMessages.review,
             controllers.ultimateParentCompany.routes.DeletionConfirmationController.onPageLoad(2) -> BaseMessages.delete
           ),
           summaryListRow(
             deemedParentModelNonUkCompany.companyName.name,
             "",
+            visuallyHiddenText = None,
             controllers.ultimateParentCompany.routes.CheckAnswersGroupStructureController.onPageLoad(3) -> BaseMessages.review,
             controllers.ultimateParentCompany.routes.DeletionConfirmationController.onPageLoad(3) -> BaseMessages.delete
           )

--- a/test/utils/InvestmentsReviewAnswersListHelperSpec.scala
+++ b/test/utils/InvestmentsReviewAnswersListHelperSpec.scala
@@ -44,18 +44,21 @@ class InvestmentsReviewAnswersListHelperSpec extends SpecBase with SummaryListRo
           summaryListRow(
             investmentName,
             "",
+            visuallyHiddenText = None,
             routes.InvestmentNameController.onPageLoad(1, CheckMode) -> BaseMessages.changeLink,
             routes.InvestmentsDeletionConfirmationController.onPageLoad(1) -> BaseMessages.delete
           ),
           summaryListRow(
             investmentName,
             "",
+            visuallyHiddenText = None,
             routes.InvestmentNameController.onPageLoad(2, CheckMode) -> BaseMessages.changeLink,
             routes.InvestmentsDeletionConfirmationController.onPageLoad(2) -> BaseMessages.delete
           ),
           summaryListRow(
             investmentName,
             "",
+            visuallyHiddenText = None,
             routes.InvestmentNameController.onPageLoad(3, CheckMode) -> BaseMessages.changeLink,
             routes.InvestmentsDeletionConfirmationController.onPageLoad(3) -> BaseMessages.delete
           )

--- a/test/utils/InvestorGroupsReviewAnswersListHelperSpec.scala
+++ b/test/utils/InvestorGroupsReviewAnswersListHelperSpec.scala
@@ -44,18 +44,21 @@ class InvestorGroupsReviewAnswersListHelperSpec extends SpecBase with SummaryLis
           summaryListRowWideKey(
             investorGroupsGroupRatioModel.investorName,
             "",
+            visuallyHiddenText = None,
             routes.InvestorGroupNameController.onPageLoad(1, NormalMode) -> BaseMessages.changeLink,
             routes.InvestorGroupsDeletionConfirmationController.onPageLoad(1) -> BaseMessages.delete
           ),
           summaryListRowWideKey(
             investorGroupsFixedRatioModel.investorName,
             "",
+            visuallyHiddenText = None,
             routes.InvestorGroupNameController.onPageLoad(2, NormalMode) -> BaseMessages.changeLink,
             routes.InvestorGroupsDeletionConfirmationController.onPageLoad(2) -> BaseMessages.delete
           ),
           summaryListRowWideKey(
             investorGroupsFixedRatioModel.investorName,
             "",
+            visuallyHiddenText = None,
             routes.InvestorGroupNameController.onPageLoad(3, NormalMode) -> BaseMessages.changeLink,
             routes.InvestorGroupsDeletionConfirmationController.onPageLoad(3) -> BaseMessages.delete
           )

--- a/test/utils/PartnershipsReviewAnswersListHelperSpec.scala
+++ b/test/utils/PartnershipsReviewAnswersListHelperSpec.scala
@@ -44,18 +44,21 @@ class PartnershipsReviewAnswersListHelperSpec extends SpecBase with SummaryListR
           summaryListRow(
             partnershipModelUK.name,
             value = "",
+            visuallyHiddenText = None,
             routes.PartnershipNameController.onPageLoad(1, NormalMode) -> BaseMessages.changeLink,
             routes.PartnershipDeletionConfirmationController.onPageLoad(1) -> BaseMessages.delete
           ),
           summaryListRow(
             partnershipModelNonUk.name,
             value = "",
+            visuallyHiddenText = None,
             routes.PartnershipNameController.onPageLoad(2, NormalMode) -> BaseMessages.changeLink,
             routes.PartnershipDeletionConfirmationController.onPageLoad(2) -> BaseMessages.delete
           ),
           summaryListRow(
             partnershipModelUK.name,
             value = "",
+            visuallyHiddenText = None,
             routes.PartnershipNameController.onPageLoad(3, NormalMode) -> BaseMessages.changeLink,
             routes.PartnershipDeletionConfirmationController.onPageLoad(3) -> BaseMessages.delete
           )

--- a/test/utils/ReviewNetTaxInterestHelperSpec.scala
+++ b/test/utils/ReviewNetTaxInterestHelperSpec.scala
@@ -44,16 +44,19 @@ class ReviewNetTaxInterestHelperSpec extends SpecBase with SummaryListRowHelper 
           summaryListRow(
             ukCompanyModelMax.companyDetails.companyName,
             s"${currencyFormat(netTaxInterestExpense)} $NetTaxInterestExpense",
+            visuallyHiddenText = None,
             controllers.ukCompanies.routes.NetTaxInterestAmountController.onPageLoad(1, ReviewMode) -> BaseMessages.changeLink
           ),
           summaryListRow(
             ukCompanyModelReactivationMaxExpense.companyDetails.companyName,
             s"${currencyFormat(netTaxInterestExpense)} $NetTaxInterestExpense",
+            visuallyHiddenText = None,
             controllers.ukCompanies.routes.NetTaxInterestAmountController.onPageLoad(2, ReviewMode) -> BaseMessages.changeLink
           ),
           summaryListRow(
             ukCompanyModelMin.companyDetails.companyName,
             s"${currencyFormat(netTaxInterestIncome)} $NetTaxInterestIncome",
+            visuallyHiddenText = None,
             controllers.ukCompanies.routes.NetTaxInterestAmountController.onPageLoad(3, ReviewMode) -> BaseMessages.changeLink
           )
         )

--- a/test/utils/ReviewReactivationsHelperSpec.scala
+++ b/test/utils/ReviewReactivationsHelperSpec.scala
@@ -43,16 +43,19 @@ class ReviewReactivationsHelperSpec extends SpecBase with SummaryListRowHelper w
           summaryListRow(
             ukCompanyModelMax.companyDetails.companyName,
             currencyFormat(ukCompanyModelMax.allocatedReactivations.fold[BigDecimal](0)(_.reactivation)),
+            visuallyHiddenText = None,
             controllers.ukCompanies.routes.ReactivationAmountController.onPageLoad(1, ReviewMode) -> BaseMessages.changeLink
           ),
           summaryListRow(
             ukCompanyModelMax.companyDetails.companyName,
             currencyFormat(ukCompanyModelMax.allocatedReactivations.fold[BigDecimal](0)(_.reactivation)),
+            visuallyHiddenText = None,
             controllers.ukCompanies.routes.ReactivationAmountController.onPageLoad(2, ReviewMode) -> BaseMessages.changeLink
           ),
           summaryListRow(
             ukCompanyModelMax.companyDetails.companyName,
             currencyFormat(ukCompanyModelMax.allocatedReactivations.fold[BigDecimal](0)(_.reactivation)),
+            visuallyHiddenText = None,
             controllers.ukCompanies.routes.ReactivationAmountController.onPageLoad(3, ReviewMode) -> BaseMessages.changeLink
           )
         )

--- a/test/utils/ReviewTaxEBITDARowsHelperSpec.scala
+++ b/test/utils/ReviewTaxEBITDARowsHelperSpec.scala
@@ -43,16 +43,19 @@ class ReviewTaxEBITDARowsHelperSpec extends SpecBase with SummaryListRowHelper w
           summaryListRow(
             ukCompanyModelMax.companyDetails.companyName,
             currencyFormat(ukCompanyModelMax.taxEBITDA.getOrElse(0)),
+            visuallyHiddenText = None,
             controllers.ukCompanies.routes.EnterCompanyTaxEBITDAController.onPageLoad(1, ReviewMode) -> BaseMessages.changeLink
           ),
           summaryListRow(
             ukCompanyModelMax.companyDetails.companyName,
             currencyFormat(ukCompanyModelMax.taxEBITDA.getOrElse(0)),
+            visuallyHiddenText = None,
             controllers.ukCompanies.routes.EnterCompanyTaxEBITDAController.onPageLoad(2, ReviewMode) -> BaseMessages.changeLink
           ),
           summaryListRow(
             ukCompanyModelMax.companyDetails.companyName,
             currencyFormat(ukCompanyModelMax.taxEBITDA.getOrElse(0)),
+            visuallyHiddenText = None,
             controllers.ukCompanies.routes.EnterCompanyTaxEBITDAController.onPageLoad(3, ReviewMode) -> BaseMessages.changeLink
           )
         )

--- a/test/utils/UkCompaniesReviewAnswersListHelperSpec.scala
+++ b/test/utils/UkCompaniesReviewAnswersListHelperSpec.scala
@@ -42,18 +42,21 @@ class UkCompaniesReviewAnswersListHelperSpec extends SpecBase with SummaryListRo
           summaryListRow(
             ukCompanyModelMax.companyDetails.companyName,
             ukCompanyModelMax.companyDetails.ctutr,
+            visuallyHiddenText = None,
             controllers.ukCompanies.routes.CheckAnswersUkCompanyController.onPageLoad(1) -> BaseMessages.review,
             controllers.ukCompanies.routes.UkCompaniesDeletionConfirmationController.onPageLoad(1) -> BaseMessages.delete
           ),
           summaryListRow(
             ukCompanyModelMax.companyDetails.companyName,
             ukCompanyModelMax.companyDetails.ctutr,
+            visuallyHiddenText = None,
             controllers.ukCompanies.routes.CheckAnswersUkCompanyController.onPageLoad(2) -> BaseMessages.review,
             controllers.ukCompanies.routes.UkCompaniesDeletionConfirmationController.onPageLoad(2) -> BaseMessages.delete
           ),
           summaryListRow(
             ukCompanyModelMax.companyDetails.companyName,
             ukCompanyModelMax.companyDetails.ctutr,
+            visuallyHiddenText = None,
             controllers.ukCompanies.routes.CheckAnswersUkCompanyController.onPageLoad(3) -> BaseMessages.review,
             controllers.ukCompanies.routes.UkCompaniesDeletionConfirmationController.onPageLoad(3) -> BaseMessages.delete
           )

--- a/test/viewmodels/SummaryListRowHelperSpec.scala
+++ b/test/viewmodels/SummaryListRowHelperSpec.scala
@@ -17,11 +17,8 @@
 package viewmodels
 
 import base.SpecBase
-import play.api.mvc._
-import play.api.mvc.Responses._
-import play.api.i18n.MessagesApi
 import uk.gov.hmrc.govukfrontend.views.viewmodels.summarylist._
-import uk.gov.hmrc.govukfrontend.views.viewmodels.content.{HtmlContent, Text}
+import uk.gov.hmrc.govukfrontend.views.viewmodels.content.Text
 
 class SummaryListRowHelperSpec extends SpecBase {
   
@@ -45,21 +42,21 @@ class SummaryListRowHelperSpec extends SpecBase {
 
   "summaryListRowSpecifyingClass" must  {
 
-    val action = Action { Ok() } 
+    val action = controllers.checkTotals.routes.ReviewNetTaxInterestController.onPageLoad()
 
     "default to the label text where hidden text is not passed in" in {
       val label = "Label"
       val visuallyHiddenText = None
       val expectedActions = Actions(
         items = Seq(ActionItem(
-          href = "Some URL",
+          href = "/interest-restriction-return/check-totals/review-net-tax-interest",
           content = Text("Change"),
           visuallyHiddenText = Some("Label")
         )),
         classes = "govuk-!-width-one-third"
       )
       val summaryListRowResult = TestHelper.summaryListRow(label, "value", visuallyHiddenText, action -> "Change")
-      summaryListRowResult.actions mustEqual expectedActions
+      summaryListRowResult.actions mustEqual Some(expectedActions)
     }
 
     "return the hidden text where it is passed in" in {
@@ -67,14 +64,14 @@ class SummaryListRowHelperSpec extends SpecBase {
       val visuallyHiddenText = Some("Hidden text")
       val expectedActions = Actions(
         items = Seq(ActionItem(
-          href = "Some URL",
+          href = "/interest-restriction-return/check-totals/review-net-tax-interest",
           content = Text("Change"),
           visuallyHiddenText = Some("Hidden text")
         )),
         classes = "govuk-!-width-one-third"
       )
       val summaryListRowResult = TestHelper.summaryListRow(label, "value", visuallyHiddenText, action -> "Change")
-      summaryListRowResult.actions mustEqual expectedActions
+      summaryListRowResult.actions mustEqual Some(expectedActions)
     }  
   }
 

--- a/test/viewmodels/SummaryListRowHelperSpec.scala
+++ b/test/viewmodels/SummaryListRowHelperSpec.scala
@@ -1,0 +1,81 @@
+/*
+ * Copyright 2021 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package viewmodels
+
+import base.SpecBase
+import play.api.mvc._
+import play.api.mvc.Responses._
+import play.api.i18n.MessagesApi
+import uk.gov.hmrc.govukfrontend.views.viewmodels.summarylist._
+import uk.gov.hmrc.govukfrontend.views.viewmodels.content.{HtmlContent, Text}
+
+class SummaryListRowHelperSpec extends SpecBase {
+  
+  object TestHelper extends SummaryListRowHelper
+
+  "defaultVisuallyHiddenText" must {
+
+    "default to the label text where hidden text is not passed in" in {
+      val label = "Label"
+      val visuallyHiddenText = None
+      TestHelper.defaultVisuallyHiddenText(label, visuallyHiddenText) mustEqual "Label"
+    }
+
+    "return the hidden text where it is passed in" in {
+      val label = "Label"
+      val visuallyHiddenText = Some("Hidden text")
+      TestHelper.defaultVisuallyHiddenText(label, visuallyHiddenText) mustEqual "Hidden text"
+    }
+
+  }
+
+  "summaryListRowSpecifyingClass" must  {
+
+    val action = Action { Ok() } 
+
+    "default to the label text where hidden text is not passed in" in {
+      val label = "Label"
+      val visuallyHiddenText = None
+      val expectedActions = Actions(
+        items = Seq(ActionItem(
+          href = "Some URL",
+          content = Text("Change"),
+          visuallyHiddenText = Some("Label")
+        )),
+        classes = "govuk-!-width-one-third"
+      )
+      val summaryListRowResult = TestHelper.summaryListRow(label, "value", visuallyHiddenText, action -> "Change")
+      summaryListRowResult.actions mustEqual expectedActions
+    }
+
+    "return the hidden text where it is passed in" in {
+      val label = "Label"
+      val visuallyHiddenText = Some("Hidden text")
+      val expectedActions = Actions(
+        items = Seq(ActionItem(
+          href = "Some URL",
+          content = Text("Change"),
+          visuallyHiddenText = Some("Hidden text")
+        )),
+        classes = "govuk-!-width-one-third"
+      )
+      val summaryListRowResult = TestHelper.summaryListRow(label, "value", visuallyHiddenText, action -> "Change")
+      summaryListRowResult.actions mustEqual expectedActions
+    }  
+  }
+
+}


### PR DESCRIPTION
See the changes to app/viewmodels/SummaryListRowHelper.scala

We now take the label as visually hidden text for screenreaders, but we also have a param to allow specific text for the row. Currently we default everywhere to the label (but this still meant a change to every instantiation of a SummaryListRow because of the pre-existing varargs param and the fact you can't default params if you have one.