### PR TITLE
CIR-1180 (Data clearance for Full or Abbreviated return page)

### DIFF
--- a/app/models/UserAnswers.scala
+++ b/app/models/UserAnswers.scala
@@ -53,9 +53,7 @@ final case class UserAnswers(
     page.cleanup(Some(value),this).flatMap {
       cleanedUserAnswers => {
         cleanedUserAnswers.setData(page.path, getList(page).+:(value)).flatMap {
-          d => {
-            Try(copy(data = d, lastPageSaved = Some(page)))
-          }
+          d => Try(copy(data = d, lastPageSaved = Some(page)))
         }
       }
     }

--- a/app/models/UserAnswers.scala
+++ b/app/models/UserAnswers.scala
@@ -40,24 +40,25 @@ final case class UserAnswers(
     page.path.read[Seq[A]].reads(data).getOrElse(Seq.empty)
 
   def set[A](page: QuestionPage[A], value: A, idx: Option[Int] = None)(implicit writes: Writes[A]): Try[UserAnswers] = {
-    setData(path(page, idx), value).flatMap {
-      d => {
-        cleanUpData(page, value, d)
+    page.cleanup(Some(value),this).flatMap {
+      cleanedUserAnswers => {
+        cleanedUserAnswers.setData(path(page,idx),value).flatMap {
+          d => Try(copy(data = d, lastPageSaved = Some(page)))
+        }
       }
     }
   }
 
   def appendList[A](page: QuestionPage[A], value: A)(implicit writes: Writes[A], rds: Reads[A]): Try[UserAnswers] = {
-    setData(page.path, getList(page).+:(value)).flatMap {
-      d => {
-        cleanUpData(page, value, d)
+    page.cleanup(Some(value),this).flatMap {
+      cleanedUserAnswers => {
+        cleanedUserAnswers.setData(page.path, getList(page).+:(value)).flatMap {
+          d => {
+            Try(copy(data = d, lastPageSaved = Some(page)))
+          }
+        }
       }
     }
-  }
-
-  private def cleanUpData[A](page: QuestionPage[A], value: A, d: JsObject) = {
-    val updatedAnswers = copy(data = d, lastPageSaved = Some(page))
-    page.cleanup(Some(value), updatedAnswers)
   }
 
   private def setData[A](path: JsPath, value: A)(implicit writes: Writes[A]): Try[JsObject] = {

--- a/app/navigation/AboutReturnNavigator.scala
+++ b/app/navigation/AboutReturnNavigator.scala
@@ -20,6 +20,7 @@ import javax.inject.{Inject, Singleton}
 import controllers.aboutReturn.{routes => aboutReturnRoutes}
 import controllers.ultimateParentCompany.{routes => ultimateParentCompanyRoutes}
 import controllers.routes
+import models.FullOrAbbreviatedReturn.{Abbreviated, Full}
 import models._
 import pages._
 import pages.aboutReturn._
@@ -57,6 +58,7 @@ class AboutReturnNavigator @Inject()() extends Navigator {
 
   val checkRouteMap: Map[Page, UserAnswers => Call] = Map[Page, UserAnswers => Call](
     ReportingCompanyAppointedPage -> normalRoutes(ReportingCompanyAppointedPage),
+    FullOrAbbreviatedReturnPage -> (fullOrAbbreviatedReturnCheckRoute(_)),
     AgentActingOnBehalfOfCompanyPage -> (_.get(AgentActingOnBehalfOfCompanyPage) match {
       case Some(true) => aboutReturnRoutes.AgentNameController.onPageLoad(CheckMode)
       case Some(false) => checkAnswers
@@ -68,6 +70,14 @@ class AboutReturnNavigator @Inject()() extends Navigator {
       case _ => aboutReturnRoutes.RevisingReturnController.onPageLoad(NormalMode)
     })
   ).withDefaultValue(_ => checkAnswers)
+
+  def fullOrAbbreviatedReturnCheckRoute(userAnswers: UserAnswers): Call = {
+    if (userAnswers.get(RevisingReturnPage).isDefined) {
+      checkAnswers
+    } else {
+      aboutReturnRoutes.RevisingReturnController.onPageLoad(NormalMode)
+    }
+  }
 
   private def checkAnswers = aboutReturnRoutes.CheckAnswersAboutReturnController.onPageLoad()
   private def nextSection(mode: Mode): Call = ultimateParentCompanyRoutes.ReportingCompanySameAsParentController.onPageLoad(mode)

--- a/app/pages/Page.scala
+++ b/app/pages/Page.scala
@@ -144,8 +144,7 @@ object Page {
     Section.ReviewAndComplete -> reviewAndCompleteSectionPages,
     Section.UltimateParentCompany -> ultimateParentCompanySectionPages
   )
-
-
+  
   val pages: Map[String, Page] = sections.flatMap{
     section => section._2.map(page => page.toString -> page)
   } ++ Map(
@@ -153,15 +152,11 @@ object Page {
     ContinueSavedReturnPage.toString -> ContinueSavedReturnPage
   )
 
-  val allQuestionPages = toQuestionPages(pages)
+  val allQuestionPages = pages.values.collect{ case a: QuestionPage[_] => a}.toList
 
   def apply(page: String): Page = pages(page)
 
   def unapply(arg: Page): String = pages.map(_.swap).apply(arg)
-
-  private def toQuestionPages(pages: Map[String,Page]): List[QuestionPage[_]] = {
-    pages.values.collect{ case a: QuestionPage[_] => a}.toList
-  }
 
   implicit val reads: Reads[Page] = JsPath.read[String].map(apply)
   implicit val writes: Writes[Page] = Writes { page => JsString(unapply(page)) }

--- a/app/pages/Page.scala
+++ b/app/pages/Page.scala
@@ -153,7 +153,6 @@ object Page {
     ContinueSavedReturnPage.toString -> ContinueSavedReturnPage
   )
 
-  val allPagesWithoutAboutSection = toQuestionPages(pages.--(aboutReturnSectionPages.map(p => p.toString)))
   val allQuestionPages = toQuestionPages(pages)
 
   def apply(page: String): Page = pages(page)

--- a/app/pages/Page.scala
+++ b/app/pages/Page.scala
@@ -144,7 +144,6 @@ object Page {
     Section.UltimateParentCompany -> ultimateParentCompanySectionPages
   )
 
-
   
   val pages: Map[String, Page] = sections.flatMap{
     section => section._2.map(page => page.toString -> page)

--- a/app/pages/Page.scala
+++ b/app/pages/Page.scala
@@ -24,7 +24,6 @@ import pages.ultimateParentCompany._
 import pages.reviewAndComplete.ReviewAndCompletePage
 import pages.aboutReturn._
 import pages.ukCompanies._
-import pages.Page.pages
 import play.api.libs.json.{JsPath, JsString, Reads, Writes}
 
 import scala.language.implicitConversions
@@ -144,6 +143,8 @@ object Page {
     Section.ReviewAndComplete -> reviewAndCompleteSectionPages,
     Section.UltimateParentCompany -> ultimateParentCompanySectionPages
   )
+
+
   
   val pages: Map[String, Page] = sections.flatMap{
     section => section._2.map(page => page.toString -> page)

--- a/app/pages/Page.scala
+++ b/app/pages/Page.scala
@@ -24,6 +24,7 @@ import pages.ultimateParentCompany._
 import pages.reviewAndComplete.ReviewAndCompletePage
 import pages.aboutReturn._
 import pages.ukCompanies._
+import pages.Page.pages
 import play.api.libs.json.{JsPath, JsString, Reads, Writes}
 
 import scala.language.implicitConversions
@@ -152,11 +153,16 @@ object Page {
     ContinueSavedReturnPage.toString -> ContinueSavedReturnPage
   )
 
-  val allQuestionPages = pages.values.collect{ case a: QuestionPage[_] => a}.toList
+  val allPagesWithoutAboutSection = toQuestionPages(pages.--(aboutReturnSectionPages.map(p => p.toString)))
+  val allQuestionPages = toQuestionPages(pages)
 
   def apply(page: String): Page = pages(page)
 
   def unapply(arg: Page): String = pages.map(_.swap).apply(arg)
+
+  private def toQuestionPages(pages: Map[String,Page]): List[QuestionPage[_]] = {
+    pages.values.collect{ case a: QuestionPage[_] => a}.toList
+  }
 
   implicit val reads: Reads[Page] = JsPath.read[String].map(apply)
   implicit val writes: Writes[Page] = Writes { page => JsString(unapply(page)) }

--- a/app/pages/aboutReturn/FullOrAbbreviatedReturnPage.scala
+++ b/app/pages/aboutReturn/FullOrAbbreviatedReturnPage.scala
@@ -16,9 +16,8 @@
 
 package pages.aboutReturn
 
-import models.FullOrAbbreviatedReturn.{Abbreviated, Full}
 import models.{FullOrAbbreviatedReturn, UserAnswers}
-import pages.Page.allPagesWithoutAboutSection
+import pages.Page.{allQuestionPages}
 import pages.QuestionPage
 import play.api.libs.json.JsPath
 
@@ -31,21 +30,19 @@ case object FullOrAbbreviatedReturnPage extends QuestionPage[FullOrAbbreviatedRe
   override def toString: String = "fullOrAbbreviatedReturn"
 
   override def cleanup(value: Option[FullOrAbbreviatedReturn], userAnswers: UserAnswers): Try[UserAnswers] = {
-    val answerTest = userAnswers.get(FullOrAbbreviatedReturnPage)
+    val currentAnswer = userAnswers.get(FullOrAbbreviatedReturnPage)
 
-    value match {
-      case Some(Full) => {
-        answerTest match {
-          case Some(Abbreviated) =>userAnswers.remove(allPagesWithoutAboutSection)
-          case _ => super.cleanup(value, userAnswers)
-        }
-      }
-      case _ => {
-        answerTest match {
-          case Some(Full) => userAnswers.remove(allPagesWithoutAboutSection)
-          case _ => super.cleanup(value, userAnswers)
-        }
-      }
+    if (currentAnswer == value) {
+      super.cleanup(value, userAnswers)
+    } else {
+      userAnswers.remove(allPagesFromFullOrAbbreviated)
     }
+  }
+
+  private def allPagesFromFullOrAbbreviated: Seq[QuestionPage[_]] = {
+    allQuestionPages.filterNot(p => p == ReportingCompanyAppointedPage ||
+      p == AgentActingOnBehalfOfCompanyPage ||
+      p == AgentNamePage ||
+      p == FullOrAbbreviatedReturnPage)
   }
 }

--- a/app/pages/aboutReturn/FullOrAbbreviatedReturnPage.scala
+++ b/app/pages/aboutReturn/FullOrAbbreviatedReturnPage.scala
@@ -16,13 +16,35 @@
 
 package pages.aboutReturn
 
-import models.FullOrAbbreviatedReturn
+import models.FullOrAbbreviatedReturn.{Abbreviated, Full}
+import models.{FullOrAbbreviatedReturn, UserAnswers}
+import pages.Page.allPagesWithoutAboutSection
 import pages.QuestionPage
 import play.api.libs.json.JsPath
+
+import scala.util.Try
 
 case object FullOrAbbreviatedReturnPage extends QuestionPage[FullOrAbbreviatedReturn] {
 
   override def path: JsPath = JsPath \ toString
 
   override def toString: String = "fullOrAbbreviatedReturn"
+
+  override def cleanup(value: Option[FullOrAbbreviatedReturn], userAnswers: UserAnswers): Try[UserAnswers] = {
+    val answerTest = userAnswers.get(FullOrAbbreviatedReturnPage)
+
+    value match {
+      case Some(Full) => {
+        answerTest match {
+          case Some(Abbreviated) =>{
+            userAnswers.remove(allPagesWithoutAboutSection)
+          }
+          case _ => super.cleanup(value, userAnswers)
+        }
+      }
+      case _ => {
+        super.cleanup(value, userAnswers)
+      }
+    }
+  }
 }

--- a/app/pages/aboutReturn/FullOrAbbreviatedReturnPage.scala
+++ b/app/pages/aboutReturn/FullOrAbbreviatedReturnPage.scala
@@ -36,14 +36,15 @@ case object FullOrAbbreviatedReturnPage extends QuestionPage[FullOrAbbreviatedRe
     value match {
       case Some(Full) => {
         answerTest match {
-          case Some(Abbreviated) =>{
-            userAnswers.remove(allPagesWithoutAboutSection)
-          }
+          case Some(Abbreviated) =>userAnswers.remove(allPagesWithoutAboutSection)
           case _ => super.cleanup(value, userAnswers)
         }
       }
       case _ => {
-        super.cleanup(value, userAnswers)
+        answerTest match {
+          case Some(Full) => userAnswers.remove(allPagesWithoutAboutSection)
+          case _ => super.cleanup(value, userAnswers)
+        }
       }
     }
   }

--- a/test/navigation/AboutReturnNavigatorSpec.scala
+++ b/test/navigation/AboutReturnNavigatorSpec.scala
@@ -22,7 +22,7 @@ import controllers.ultimateParentCompany.{routes => ultimateParentCompanyRoutes}
 import models._
 import pages.Page
 import pages.aboutReturn._
-import pages.groupLevelInformation.RevisingReturnPage
+import pages.groupLevelInformation.{DisallowedAmountPage, GroupSubjectToRestrictionsPage, RevisingReturnPage}
 
 class AboutReturnNavigatorSpec extends SpecBase {
 
@@ -161,6 +161,27 @@ class AboutReturnNavigatorSpec extends SpecBase {
             aboutReturnRoutes.CheckAnswersAboutReturnController.onPageLoad()
         }
       }
+
+      "from the Full or Abbreviated Return page" should {
+        "go to the Check Your Answers page when there is no changes in the answer" in {
+          val userAnswers = for {
+            fullOrReturnPage <- emptyUserAnswers.set(FullOrAbbreviatedReturnPage,FullOrAbbreviatedReturn.Full)
+            revisingReturnPage <- fullOrReturnPage.set(RevisingReturnPage, true)
+          } yield revisingReturnPage
+
+          navigator.nextPage(FullOrAbbreviatedReturnPage, CheckMode, userAnswers.get) mustBe
+            aboutReturnRoutes.CheckAnswersAboutReturnController.onPageLoad()
+        }
+
+        "go down the normal route if there has been changes in the answer" in {
+          val userAnswers = emptyUserAnswers.set(FullOrAbbreviatedReturnPage, FullOrAbbreviatedReturn.Full)
+            .map(fullOrReturnPage => fullOrReturnPage)
+
+          navigator.nextPage(FullOrAbbreviatedReturnPage, CheckMode, userAnswers.get) mustBe
+            aboutReturnRoutes.RevisingReturnController.onPageLoad(NormalMode)
+        }
+      }
+
 
       "from the Reporting Company UTR page" should {
 

--- a/test/pages/aboutReturn/FullOrAbbreviatedReturnPageSpec.scala
+++ b/test/pages/aboutReturn/FullOrAbbreviatedReturnPageSpec.scala
@@ -38,7 +38,7 @@ class FullOrAbbreviatedReturnPageSpec extends PageBehaviours {
 
   "Cleanup" when {
     "A user has selected `Full` return" when {
-      "When they revisit the page but do not change the answer" should {
+      "They revisit the page but do not change the answer" should {
         "Not delete any data" in {
           forAll(arbitrary[UserAnswers]) {
             userAnswers =>
@@ -65,15 +65,16 @@ class FullOrAbbreviatedReturnPageSpec extends PageBehaviours {
       }
     }
 
-    "When they revisit the page and change the answer to `Abbreviated`" should {
+    "They revisit the page and change the answer to `Abbreviated`" should {
       "remove all answers from 'FullOrAbbreviatedReturnPage' onwards" in {
         forAll(arbitrary[UserAnswers]) {
           userAnswers =>
             val result = userAnswers
               .set(FullOrAbbreviatedReturnPage,FullOrAbbreviatedReturn.values.last).success.value
-              .set(RevisingReturnPage,false).success.value
-              .set(AgentNamePage,"John Doe").success.value
               .set(ReportingCompanyAppointedPage,true).success.value
+              .set(AgentActingOnBehalfOfCompanyPage, true).success.value
+              .set(AgentNamePage,"John Doe").success.value
+              .set(RevisingReturnPage,false).success.value
               .set(GroupInterestAllowancePage,BigDecimal(3.324234234)).success.value
               .set(ConsentingCompanyPage,true).success.value
               .set(AddInvestorGroupPage,true).success.value
@@ -82,8 +83,10 @@ class FullOrAbbreviatedReturnPageSpec extends PageBehaviours {
 
 
             result.get(ReportingCompanyAppointedPage) mustBe defined
-            result.get(RevisingReturnPage) mustBe defined
             result.get(AgentNamePage) mustBe defined
+            result.get(AgentActingOnBehalfOfCompanyPage) mustBe defined
+            result.get(FullOrAbbreviatedReturnPage) mustBe defined
+            result.get(RevisingReturnPage) must not be defined
             result.get(GroupInterestAllowancePage) must not be defined
             result.get(ConsentingCompanyPage) must not be defined
             result.get(AddInvestorGroupPage) must not be defined
@@ -126,9 +129,10 @@ class FullOrAbbreviatedReturnPageSpec extends PageBehaviours {
             userAnswers =>
               val result = userAnswers
                 .set(FullOrAbbreviatedReturnPage,FullOrAbbreviatedReturn.values.head).success.value
-                .set(RevisingReturnPage,false).success.value
-                .set(AgentNamePage,"John Doe").success.value
                 .set(ReportingCompanyAppointedPage,true).success.value
+                .set(AgentActingOnBehalfOfCompanyPage, true).success.value
+                .set(AgentNamePage,"John Doe").success.value
+                .set(RevisingReturnPage,false).success.value
                 .set(GroupInterestAllowancePage,BigDecimal(3.324234234)).success.value
                 .set(ConsentingCompanyPage,true).success.value
                 .set(AddInvestorGroupPage,true).success.value
@@ -137,8 +141,10 @@ class FullOrAbbreviatedReturnPageSpec extends PageBehaviours {
 
 
               result.get(ReportingCompanyAppointedPage) mustBe defined
-              result.get(RevisingReturnPage) mustBe defined
               result.get(AgentNamePage) mustBe defined
+              result.get(AgentActingOnBehalfOfCompanyPage) mustBe defined
+              result.get(FullOrAbbreviatedReturnPage) mustBe defined
+              result.get(RevisingReturnPage) must not be defined
               result.get(GroupInterestAllowancePage) must not be defined
               result.get(ConsentingCompanyPage) must not be defined
               result.get(AddInvestorGroupPage) must not be defined

--- a/test/pages/aboutReturn/FullOrAbbreviatedReturnPageSpec.scala
+++ b/test/pages/aboutReturn/FullOrAbbreviatedReturnPageSpec.scala
@@ -16,8 +16,14 @@
 
 package pages.aboutReturn
 
-import models.FullOrAbbreviatedReturn
+import models.SectionStatus.writes
+import models.{FullOrAbbreviatedReturn, UserAnswers}
+import org.scalacheck.Arbitrary.arbitrary
 import pages.behaviours.PageBehaviours
+import pages.elections.AddInvestorGroupPage
+import pages.groupLevelInformation.{GroupInterestAllowancePage, RevisingReturnPage}
+import pages.ukCompanies.ConsentingCompanyPage
+import pages.ultimateParentCompany.ParentCompanySAUTRPage
 
 class FullOrAbbreviatedReturnPageSpec extends PageBehaviours {
 
@@ -28,5 +34,63 @@ class FullOrAbbreviatedReturnPageSpec extends PageBehaviours {
     beSettable[FullOrAbbreviatedReturn](FullOrAbbreviatedReturnPage)
 
     beRemovable[FullOrAbbreviatedReturn](FullOrAbbreviatedReturnPage)
+  }
+
+  "Cleanup" when {
+    "A user has selected `Full` return" when {
+      "When they revisit the page but do not change the answer" should {
+        "Not delete any data" in {
+          forAll(arbitrary[UserAnswers]) {
+            userAnswers =>
+              val result = userAnswers
+                .set(FullOrAbbreviatedReturnPage,FullOrAbbreviatedReturn.values.head).success.value
+                .set(RevisingReturnPage,false).success.value
+                .set(AgentNamePage,"John Doe").success.value
+                .set(ReportingCompanyAppointedPage,true).success.value
+                .set(GroupInterestAllowancePage,BigDecimal(3.324234234)).success.value
+                .set(ConsentingCompanyPage,true).success.value
+                .set(AddInvestorGroupPage,true).success.value
+                .set(ParentCompanySAUTRPage,"111111111").success.value
+                .set(FullOrAbbreviatedReturnPage,FullOrAbbreviatedReturn.values.head).success.value
+
+
+              result.get(ReportingCompanyAppointedPage) mustBe defined
+              result.get(RevisingReturnPage) mustBe defined
+              result.get(AgentNamePage) mustBe defined
+              result.get(GroupInterestAllowancePage) mustBe defined
+              result.get(ConsentingCompanyPage) mustBe defined
+              result.get(AddInvestorGroupPage) mustBe defined
+              result.get(ParentCompanySAUTRPage) mustBe defined
+        }
+      }
+    }
+
+    "When they revisit the page and change the answer to `Abbreviated`" should {
+      "remove all answers from 'FullOrAbbreviatedReturnPage' onwards" in {
+        forAll(arbitrary[UserAnswers]) {
+          userAnswers =>
+            val result = userAnswers
+              .set(FullOrAbbreviatedReturnPage,FullOrAbbreviatedReturn.values.last).success.value
+              .set(RevisingReturnPage,false).success.value
+              .set(AgentNamePage,"John Doe").success.value
+              .set(ReportingCompanyAppointedPage,true).success.value
+              .set(GroupInterestAllowancePage,BigDecimal(3.324234234)).success.value
+              .set(ConsentingCompanyPage,true).success.value
+              .set(AddInvestorGroupPage,true).success.value
+              .set(ParentCompanySAUTRPage,"111111111").success.value
+              .set(FullOrAbbreviatedReturnPage,FullOrAbbreviatedReturn.values.head).success.value
+
+
+            result.get(ReportingCompanyAppointedPage) mustBe defined
+            result.get(RevisingReturnPage) mustBe defined
+            result.get(AgentNamePage) mustBe defined
+            result.get(GroupInterestAllowancePage) must not be defined
+            result.get(ConsentingCompanyPage) must not be defined
+            result.get(AddInvestorGroupPage) must not be defined
+            result.get(ParentCompanySAUTRPage) must not be defined
+        }
+      }
+    }
+    }
   }
 }

--- a/test/pages/aboutReturn/FullOrAbbreviatedReturnPageSpec.scala
+++ b/test/pages/aboutReturn/FullOrAbbreviatedReturnPageSpec.scala
@@ -92,5 +92,60 @@ class FullOrAbbreviatedReturnPageSpec extends PageBehaviours {
       }
     }
     }
+    "A user has selected `Abbreviated` return" when {
+      "When they revisit the page but do not change the answer" should {
+        "Not delete any data" in {
+          forAll(arbitrary[UserAnswers]) {
+            userAnswers =>
+              val result = userAnswers
+                .set(FullOrAbbreviatedReturnPage,FullOrAbbreviatedReturn.values.last).success.value
+                .set(RevisingReturnPage,false).success.value
+                .set(AgentNamePage,"John Doe").success.value
+                .set(ReportingCompanyAppointedPage,true).success.value
+                .set(GroupInterestAllowancePage,BigDecimal(3.324234234)).success.value
+                .set(ConsentingCompanyPage,true).success.value
+                .set(AddInvestorGroupPage,true).success.value
+                .set(ParentCompanySAUTRPage,"111111111").success.value
+                .set(FullOrAbbreviatedReturnPage,FullOrAbbreviatedReturn.values.last).success.value
+
+
+              result.get(ReportingCompanyAppointedPage) mustBe defined
+              result.get(RevisingReturnPage) mustBe defined
+              result.get(AgentNamePage) mustBe defined
+              result.get(GroupInterestAllowancePage) mustBe defined
+              result.get(ConsentingCompanyPage) mustBe defined
+              result.get(AddInvestorGroupPage) mustBe defined
+              result.get(ParentCompanySAUTRPage) mustBe defined
+          }
+        }
+      }
+
+      "When they revisit the page and change the answer to `Full`" should {
+        "remove all answers from 'FullOrAbbreviatedReturnPage' onwards" in {
+          forAll(arbitrary[UserAnswers]) {
+            userAnswers =>
+              val result = userAnswers
+                .set(FullOrAbbreviatedReturnPage,FullOrAbbreviatedReturn.values.head).success.value
+                .set(RevisingReturnPage,false).success.value
+                .set(AgentNamePage,"John Doe").success.value
+                .set(ReportingCompanyAppointedPage,true).success.value
+                .set(GroupInterestAllowancePage,BigDecimal(3.324234234)).success.value
+                .set(ConsentingCompanyPage,true).success.value
+                .set(AddInvestorGroupPage,true).success.value
+                .set(ParentCompanySAUTRPage,"111111111").success.value
+                .set(FullOrAbbreviatedReturnPage,FullOrAbbreviatedReturn.values.last).success.value
+
+
+              result.get(ReportingCompanyAppointedPage) mustBe defined
+              result.get(RevisingReturnPage) mustBe defined
+              result.get(AgentNamePage) mustBe defined
+              result.get(GroupInterestAllowancePage) must not be defined
+              result.get(ConsentingCompanyPage) must not be defined
+              result.get(AddInvestorGroupPage) must not be defined
+              result.get(ParentCompanySAUTRPage) must not be defined
+          }
+        }
+      }
+    }
   }
 }


### PR DESCRIPTION
**Scope**
_If a user changes from `full` to `abbreviated` then we delete all data from `FullOrAbbreviated` page onwards_
_If a user changes from `abbreviated` to `full` then we delete all data from `FullOrAbbreviated` page onwards_

**Things to take into account**
To be able to execute the above, we need to know if when a user revisits `FullOrAbbreviatedPage` has changed anything at all, if not, then we don't do a data clearance. With the current way the scaffolds were set up we can't do that as when you submit a page it first `sets` the submitted data and then does any `data clearance` tasks, meaning that previous answers have been overridden. I have changed `UserAnswers` to accommodate this, next steps is to raise a PR in the actual `scaffolds` repo as I believe it makes more sense to first perform any `clearance` and then `set` data.