### PR TITLE
CIR-1174 - Refactor and addition of ElectionsSectionStatus

### DIFF
--- a/.g8/checkboxPage/app/pages/$section;format="decap"$/$className;format="cap"$Page.scala
+++ b/.g8/checkboxPage/app/pages/$section;format="decap"$/$className;format="cap"$Page.scala
@@ -9,6 +9,4 @@ case object $className;format="cap"$Page extends QuestionPage[Set[$className;for
   
   override def toString: String = "$className;format="decap"$"
 
-  val reads = implicitly
-  val writes = implicitly
 }

--- a/.g8/checkboxPage/app/pages/$section;format="decap"$/$className;format="cap"$Page.scala
+++ b/.g8/checkboxPage/app/pages/$section;format="decap"$/$className;format="cap"$Page.scala
@@ -8,5 +8,4 @@ case object $className;format="cap"$Page extends QuestionPage[Set[$className;for
   override def path: JsPath = JsPath \ toString
   
   override def toString: String = "$className;format="decap"$"
-
 }

--- a/.g8/checkboxPage/app/pages/$section;format="decap"$/$className;format="cap"$Page.scala
+++ b/.g8/checkboxPage/app/pages/$section;format="decap"$/$className;format="cap"$Page.scala
@@ -8,4 +8,7 @@ case object $className;format="cap"$Page extends QuestionPage[Set[$className;for
   override def path: JsPath = JsPath \ toString
   
   override def toString: String = "$className;format="decap"$"
+
+  val reads = implicitly
+  val writes = implicitly
 }

--- a/.g8/datePage/app/pages/$section;format="decap"$/$className;format="cap"$Page.scala
+++ b/.g8/datePage/app/pages/$section;format="decap"$/$className;format="cap"$Page.scala
@@ -9,4 +9,7 @@ case object $className;format="cap"$Page extends QuestionPage[LocalDate] {
   override def path: JsPath = JsPath \ toString
 
   override def toString: String = "$className;format="decap"$"
+
+  val reads = implicitly
+  val writes = implicitly
 }

--- a/.g8/datePage/app/pages/$section;format="decap"$/$className;format="cap"$Page.scala
+++ b/.g8/datePage/app/pages/$section;format="decap"$/$className;format="cap"$Page.scala
@@ -10,6 +10,4 @@ case object $className;format="cap"$Page extends QuestionPage[LocalDate] {
 
   override def toString: String = "$className;format="decap"$"
 
-  val reads = implicitly
-  val writes = implicitly
 }

--- a/.g8/datePage/app/pages/$section;format="decap"$/$className;format="cap"$Page.scala
+++ b/.g8/datePage/app/pages/$section;format="decap"$/$className;format="cap"$Page.scala
@@ -9,5 +9,4 @@ case object $className;format="cap"$Page extends QuestionPage[LocalDate] {
   override def path: JsPath = JsPath \ toString
 
   override def toString: String = "$className;format="decap"$"
-
 }

--- a/.g8/decimalPage/app/pages/$section;format="decap"$/$className;format="cap"$Page.scala
+++ b/.g8/decimalPage/app/pages/$section;format="decap"$/$className;format="cap"$Page.scala
@@ -7,4 +7,7 @@ case object $className;format="cap"$Page extends QuestionPage[BigDecimal] {
   override def path: JsPath = JsPath \ toString
   
   override def toString: String = "$className;format="decap"$"
+
+  val reads = implicitly
+  val writes = implicitly
 }

--- a/.g8/decimalPage/app/pages/$section;format="decap"$/$className;format="cap"$Page.scala
+++ b/.g8/decimalPage/app/pages/$section;format="decap"$/$className;format="cap"$Page.scala
@@ -8,6 +8,4 @@ case object $className;format="cap"$Page extends QuestionPage[BigDecimal] {
   
   override def toString: String = "$className;format="decap"$"
 
-  val reads = implicitly
-  val writes = implicitly
 }

--- a/.g8/decimalPage/app/pages/$section;format="decap"$/$className;format="cap"$Page.scala
+++ b/.g8/decimalPage/app/pages/$section;format="decap"$/$className;format="cap"$Page.scala
@@ -7,5 +7,4 @@ case object $className;format="cap"$Page extends QuestionPage[BigDecimal] {
   override def path: JsPath = JsPath \ toString
   
   override def toString: String = "$className;format="decap"$"
-
 }

--- a/.g8/intPage/app/pages/$section;format="decap"$/$className;format="cap"$Page.scala
+++ b/.g8/intPage/app/pages/$section;format="decap"$/$className;format="cap"$Page.scala
@@ -8,6 +8,4 @@ case object $className;format="cap"$Page extends QuestionPage[Int] {
   
   override def toString: String = "$className;format="decap"$"
 
-  val reads = implicitly
-  val writes = implicitly
 }

--- a/.g8/intPage/app/pages/$section;format="decap"$/$className;format="cap"$Page.scala
+++ b/.g8/intPage/app/pages/$section;format="decap"$/$className;format="cap"$Page.scala
@@ -7,4 +7,7 @@ case object $className;format="cap"$Page extends QuestionPage[Int] {
   override def path: JsPath = JsPath \ toString
   
   override def toString: String = "$className;format="decap"$"
+
+  val reads = implicitly
+  val writes = implicitly
 }

--- a/.g8/intPage/app/pages/$section;format="decap"$/$className;format="cap"$Page.scala
+++ b/.g8/intPage/app/pages/$section;format="decap"$/$className;format="cap"$Page.scala
@@ -7,5 +7,4 @@ case object $className;format="cap"$Page extends QuestionPage[Int] {
   override def path: JsPath = JsPath \ toString
   
   override def toString: String = "$className;format="decap"$"
-
 }

--- a/.g8/optionsPage/app/pages/$section;format="decap"$/$className;format="cap"$Page.scala
+++ b/.g8/optionsPage/app/pages/$section;format="decap"$/$className;format="cap"$Page.scala
@@ -8,4 +8,7 @@ case object $className;format="cap"$Page extends QuestionPage[$className;format=
   override def path: JsPath = JsPath \ toString
   
   override def toString: String = "$className;format="decap"$"
+
+  val reads = implicitly
+  val writes = implicitly
 }

--- a/.g8/optionsPage/app/pages/$section;format="decap"$/$className;format="cap"$Page.scala
+++ b/.g8/optionsPage/app/pages/$section;format="decap"$/$className;format="cap"$Page.scala
@@ -8,5 +8,4 @@ case object $className;format="cap"$Page extends QuestionPage[$className;format=
   override def path: JsPath = JsPath \ toString
   
   override def toString: String = "$className;format="decap"$"
-
 }

--- a/.g8/optionsPage/app/pages/$section;format="decap"$/$className;format="cap"$Page.scala
+++ b/.g8/optionsPage/app/pages/$section;format="decap"$/$className;format="cap"$Page.scala
@@ -9,6 +9,4 @@ case object $className;format="cap"$Page extends QuestionPage[$className;format=
   
   override def toString: String = "$className;format="decap"$"
 
-  val reads = implicitly
-  val writes = implicitly
 }

--- a/.g8/stringPage/app/pages/$section;format="decap"$/$className;format="cap"$Page.scala
+++ b/.g8/stringPage/app/pages/$section;format="decap"$/$className;format="cap"$Page.scala
@@ -8,6 +8,4 @@ case object $className;format="cap"$Page extends QuestionPage[String] {
   
   override def toString: String = "$className;format="decap"$"
 
-  val reads = implicitly
-  val writes = implicitly
 }

--- a/.g8/stringPage/app/pages/$section;format="decap"$/$className;format="cap"$Page.scala
+++ b/.g8/stringPage/app/pages/$section;format="decap"$/$className;format="cap"$Page.scala
@@ -7,4 +7,7 @@ case object $className;format="cap"$Page extends QuestionPage[String] {
   override def path: JsPath = JsPath \ toString
   
   override def toString: String = "$className;format="decap"$"
+
+  val reads = implicitly
+  val writes = implicitly
 }

--- a/.g8/stringPage/app/pages/$section;format="decap"$/$className;format="cap"$Page.scala
+++ b/.g8/stringPage/app/pages/$section;format="decap"$/$className;format="cap"$Page.scala
@@ -7,5 +7,4 @@ case object $className;format="cap"$Page extends QuestionPage[String] {
   override def path: JsPath = JsPath \ toString
   
   override def toString: String = "$className;format="decap"$"
-
 }

--- a/.g8/yesNoPage/app/pages/$section;format="decap"$/$className;format="cap"$Page.scala
+++ b/.g8/yesNoPage/app/pages/$section;format="decap"$/$className;format="cap"$Page.scala
@@ -7,4 +7,7 @@ case object $className;format="cap"$Page extends QuestionPage[Boolean] {
   override def path: JsPath = JsPath \ toString
   
   override def toString: String = "$className;format="decap"$"
+
+  val reads = implicitly
+  val writes = implicitly
 }

--- a/.g8/yesNoPage/app/pages/$section;format="decap"$/$className;format="cap"$Page.scala
+++ b/.g8/yesNoPage/app/pages/$section;format="decap"$/$className;format="cap"$Page.scala
@@ -7,5 +7,4 @@ case object $className;format="cap"$Page extends QuestionPage[Boolean] {
   override def path: JsPath = JsPath \ toString
   
   override def toString: String = "$className;format="decap"$"
-
 }

--- a/.g8/yesNoPage/app/pages/$section;format="decap"$/$className;format="cap"$Page.scala
+++ b/.g8/yesNoPage/app/pages/$section;format="decap"$/$className;format="cap"$Page.scala
@@ -8,6 +8,4 @@ case object $className;format="cap"$Page extends QuestionPage[Boolean] {
   
   override def toString: String = "$className;format="decap"$"
 
-  val reads = implicitly
-  val writes = implicitly
 }

--- a/app/models/sections/AboutReturnSectionModel.scala
+++ b/app/models/sections/AboutReturnSectionModel.scala
@@ -14,17 +14,18 @@
  * limitations under the License.
  */
 
-package pages.ultimateParentCompany
+package models.sections
 
-import pages.QuestionPage
-import play.api.libs.json.JsPath
+import models.returnModels._
+import models.FullOrAbbreviatedReturn
 
-case object CheckAnswersGroupStructurePage extends QuestionPage[String] {
-
-  override def path: JsPath = JsPath \ toString
-
-  override def toString: String = "checkAnswersGroupStructure"
-
-  val reads = implicitly
-  val writes = implicitly
-}
+case class AboutReturnSectionModel(
+  appointedReportingCompany: Boolean,
+  agentDetails: AgentDetailsModel,
+  fullOrAbbreviatedReturn: FullOrAbbreviatedReturn,
+  isRevisingReturn: Boolean,
+  revisedReturnDetails: Option[String],
+  companyName: CompanyNameModel,
+  ctutr: UTRModel,
+  periodOfAccount: AccountingPeriodModel
+)

--- a/app/models/sections/ElectionsSectionModel.scala
+++ b/app/models/sections/ElectionsSectionModel.scala
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2021 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package models.sections
+
+import models.returnModels._
+
+case class ElectionsSectionModel(
+    groupRatioIsElected: Boolean,
+    groupRatioBlended: Option[GroupRatioBlendedModel],
+    groupEBITDAChargeableGainsActive: Option[Boolean],
+    groupEBITDAChargeableGainsIsElected: Option[Boolean],
+    interestAllowanceAlternativeCalcActive: Boolean,
+    interestAllowanceAlternativeCalcIsElected: Option[Boolean],
+    nonConsolidatedInvestmentsIsElected: Boolean,
+    nonConsolidatedInvestmentNames: Option[Seq[String]],
+    consolidatedPartnershipsActive: Boolean, 
+    consolidatedPartnerships: Option[ConsolidatedPartnershipModel]
+)

--- a/app/models/sections/UltimateParentCompanySectionModel.scala
+++ b/app/models/sections/UltimateParentCompanySectionModel.scala
@@ -14,17 +14,12 @@
  * limitations under the License.
  */
 
-package pages.ultimateParentCompany
+package models.sections
 
-import pages.QuestionPage
-import play.api.libs.json.JsPath
+import models.returnModels.DeemedParentModel
 
-case object CheckAnswersGroupStructurePage extends QuestionPage[String] {
-
-  override def path: JsPath = JsPath \ toString
-
-  override def toString: String = "checkAnswersGroupStructure"
-
-  val reads = implicitly
-  val writes = implicitly
-}
+case class UltimateParentCompanySectionModel(
+    reportingCompanySameAsParent: Boolean,
+    hasDeemedParent: Option[Boolean],
+    parentCompanies: Seq[DeemedParentModel]
+)

--- a/app/pages/ContinueSavedReturnPage.scala
+++ b/app/pages/ContinueSavedReturnPage.scala
@@ -25,6 +25,4 @@ case object ContinueSavedReturnPage extends QuestionPage[ContinueSavedReturn] {
 
   override def toString: String = "continueSavedReturn"
 
-  val reads = implicitly
-  val writes = implicitly
 }

--- a/app/pages/ContinueSavedReturnPage.scala
+++ b/app/pages/ContinueSavedReturnPage.scala
@@ -24,5 +24,4 @@ case object ContinueSavedReturnPage extends QuestionPage[ContinueSavedReturn] {
   override def path: JsPath = JsPath \ toString
 
   override def toString: String = "continueSavedReturn"
-
 }

--- a/app/pages/ContinueSavedReturnPage.scala
+++ b/app/pages/ContinueSavedReturnPage.scala
@@ -24,4 +24,7 @@ case object ContinueSavedReturnPage extends QuestionPage[ContinueSavedReturn] {
   override def path: JsPath = JsPath \ toString
 
   override def toString: String = "continueSavedReturn"
+
+  val reads = implicitly
+  val writes = implicitly
 }

--- a/app/pages/Page.scala
+++ b/app/pages/Page.scala
@@ -25,16 +25,20 @@ import pages.reviewAndComplete.ReviewAndCompletePage
 import pages.aboutReturn._
 import pages.ukCompanies._
 import play.api.libs.json.{JsPath, JsString, Reads, Writes}
+import models._
 
 import scala.language.implicitConversions
 
 trait Page
 
 object Page {
+  
+  implicit val reads: Reads[Page] = JsPath.read[String].map(apply)
+  implicit val writes: Writes[Page] = Writes { page => JsString(unapply(page)) }
 
   implicit def toString(page: Page): String = page.toString
 
-  val aboutReturnSectionPages: Seq[Page] = List(
+  lazy val aboutReturnSectionPages: Seq[Page] = List(
     AgentActingOnBehalfOfCompanyPage,
     AgentNamePage,
     FullOrAbbreviatedReturnPage,
@@ -49,7 +53,7 @@ object Page {
     TellUsWhatHasChangedPage
   )
 
-  val groupLevelInformationSectionPages: Seq[Page] = List(
+  lazy val groupLevelInformationSectionPages: Seq[Page] = List(
     GroupInterestAllowancePage,
     GroupInterestCapacityPage,
     GroupSubjectToReactivationsPage,
@@ -66,7 +70,7 @@ object Page {
   )
 
 
-  val ukCompaniesSectionPages: Seq[Page] = List(
+  lazy val ukCompaniesSectionPages: Seq[Page] = List(
     UkCompaniesPage,
     CheckAnswersUkCompanyPage,
     CompanyDetailsPage,
@@ -81,7 +85,7 @@ object Page {
     RestrictionAmountSameAPPage
   )
 
-  val electionsSectionPages: Seq[Page] = List(
+  lazy val electionsSectionPages: Seq[Page] = List(
     AddInvestorGroupPage,
     ElectedGroupEBITDABeforePage,
     ElectedInterestAllowanceAlternativeCalcBeforePage,
@@ -110,7 +114,7 @@ object Page {
     QICElectionPage
   )
 
-  val ultimateParentCompanySectionPages: Seq[Page] = List(
+  lazy val ultimateParentCompanySectionPages: Seq[Page] = List(
     CheckAnswersGroupStructurePage,
     DeletionConfirmationPage,
     CountryOfIncorporationPage,
@@ -124,17 +128,17 @@ object Page {
     DeemedParentPage
   )
 
-  val checkTotalsSectionPages: Seq[Page] = List(
+  lazy val checkTotalsSectionPages: Seq[Page] = List(
     DerivedCompanyPage,
     ReviewTaxEBITDAPage,
     ReviewNetTaxInterestPage
   )
 
-  val reviewAndCompleteSectionPages: Seq[Page] = List(
+  lazy val reviewAndCompleteSectionPages: Seq[Page] = List(
     ReviewAndCompletePage
   )
 
-  val sections = Map(
+  lazy val sections = Map(
     Section.AboutReturn -> aboutReturnSectionPages,
     Section.GroupLevelInformation -> groupLevelInformationSectionPages,
     Section.UkCompanies -> ukCompaniesSectionPages,
@@ -145,19 +149,17 @@ object Page {
   )
 
   
-  val pages: Map[String, Page] = sections.flatMap{
+  lazy val pages: Map[String, Page] = sections.flatMap{
     section => section._2.map(page => page.toString -> page)
   } ++ Map(
     ConfirmationPage.toString -> ConfirmationPage,
     ContinueSavedReturnPage.toString -> ContinueSavedReturnPage
   )
 
-  val allQuestionPages = pages.values.collect{ case a: QuestionPage[_] => a}.toList
+  lazy val allQuestionPages = pages.values.collect{ case a: QuestionPage[_] => a}.toList
 
   def apply(page: String): Page = pages(page)
 
   def unapply(arg: Page): String = pages.map(_.swap).apply(arg)
 
-  implicit val reads: Reads[Page] = JsPath.read[String].map(apply)
-  implicit val writes: Writes[Page] = Writes { page => JsString(unapply(page)) }
 }

--- a/app/pages/QuestionPage.scala
+++ b/app/pages/QuestionPage.scala
@@ -17,7 +17,10 @@
 package pages
 
 import queries.{Gettable, Settable}
+import play.api.libs.json.{Reads, Writes}
 
 trait QuestionPage[A] extends Page with Gettable[A] with Settable[A] {
   type Data = A
+  def reads: Reads[A]
+  def writes: Writes[A]
 }

--- a/app/pages/QuestionPage.scala
+++ b/app/pages/QuestionPage.scala
@@ -19,8 +19,6 @@ package pages
 import queries.{Gettable, Settable}
 import play.api.libs.json.{Reads, Writes}
 
-trait QuestionPage[A] extends Page with Gettable[A] with Settable[A] {
+abstract class QuestionPage[A](implicit val reads: Reads[A], val writes: Writes[A]) extends Page with Gettable[A] with Settable[A] {
   type Data = A
-  def reads: Reads[A]
-  def writes: Writes[A]
 }

--- a/app/pages/aboutReturn/AccountingPeriodPage.scala
+++ b/app/pages/aboutReturn/AccountingPeriodPage.scala
@@ -25,4 +25,7 @@ case object AccountingPeriodPage extends QuestionPage[AccountingPeriodModel] {
   override def path: JsPath = JsPath \ toString
 
   override def toString: String = "accountingPeriod"
+
+  val reads = implicitly
+  val writes = implicitly
 }

--- a/app/pages/aboutReturn/AccountingPeriodPage.scala
+++ b/app/pages/aboutReturn/AccountingPeriodPage.scala
@@ -26,6 +26,4 @@ case object AccountingPeriodPage extends QuestionPage[AccountingPeriodModel] {
 
   override def toString: String = "accountingPeriod"
 
-  val reads = implicitly
-  val writes = implicitly
 }

--- a/app/pages/aboutReturn/AccountingPeriodPage.scala
+++ b/app/pages/aboutReturn/AccountingPeriodPage.scala
@@ -25,5 +25,4 @@ case object AccountingPeriodPage extends QuestionPage[AccountingPeriodModel] {
   override def path: JsPath = JsPath \ toString
 
   override def toString: String = "accountingPeriod"
-
 }

--- a/app/pages/aboutReturn/AgentActingOnBehalfOfCompanyPage.scala
+++ b/app/pages/aboutReturn/AgentActingOnBehalfOfCompanyPage.scala
@@ -39,6 +39,4 @@ case object AgentActingOnBehalfOfCompanyPage extends QuestionPage[Boolean] {
     }
   }
 
-  val reads = implicitly
-  val writes = implicitly
 }

--- a/app/pages/aboutReturn/AgentActingOnBehalfOfCompanyPage.scala
+++ b/app/pages/aboutReturn/AgentActingOnBehalfOfCompanyPage.scala
@@ -38,5 +38,4 @@ case object AgentActingOnBehalfOfCompanyPage extends QuestionPage[Boolean] {
       }
     }
   }
-
 }

--- a/app/pages/aboutReturn/AgentActingOnBehalfOfCompanyPage.scala
+++ b/app/pages/aboutReturn/AgentActingOnBehalfOfCompanyPage.scala
@@ -38,4 +38,7 @@ case object AgentActingOnBehalfOfCompanyPage extends QuestionPage[Boolean] {
       }
     }
   }
+
+  val reads = implicitly
+  val writes = implicitly
 }

--- a/app/pages/aboutReturn/AgentNamePage.scala
+++ b/app/pages/aboutReturn/AgentNamePage.scala
@@ -24,4 +24,7 @@ case object AgentNamePage extends QuestionPage[String] {
   override def path: JsPath = JsPath \ toString
 
   override def toString: String = "agentName"
+
+  val reads = implicitly
+  val writes = implicitly
 }

--- a/app/pages/aboutReturn/AgentNamePage.scala
+++ b/app/pages/aboutReturn/AgentNamePage.scala
@@ -24,5 +24,4 @@ case object AgentNamePage extends QuestionPage[String] {
   override def path: JsPath = JsPath \ toString
 
   override def toString: String = "agentName"
-
 }

--- a/app/pages/aboutReturn/AgentNamePage.scala
+++ b/app/pages/aboutReturn/AgentNamePage.scala
@@ -25,6 +25,4 @@ case object AgentNamePage extends QuestionPage[String] {
 
   override def toString: String = "agentName"
 
-  val reads = implicitly
-  val writes = implicitly
 }

--- a/app/pages/aboutReturn/CheckAnswersAboutReturnPage.scala
+++ b/app/pages/aboutReturn/CheckAnswersAboutReturnPage.scala
@@ -25,6 +25,4 @@ case object CheckAnswersAboutReturnPage extends QuestionPage[String] {
 
   override def toString: String = "checkAnswersAboutReturn"
 
-  val reads = implicitly
-  val writes = implicitly
 }

--- a/app/pages/aboutReturn/CheckAnswersAboutReturnPage.scala
+++ b/app/pages/aboutReturn/CheckAnswersAboutReturnPage.scala
@@ -24,4 +24,7 @@ case object CheckAnswersAboutReturnPage extends QuestionPage[String] {
   override def path: JsPath = JsPath \ toString
 
   override def toString: String = "checkAnswersAboutReturn"
+
+  val reads = implicitly
+  val writes = implicitly
 }

--- a/app/pages/aboutReturn/CheckAnswersAboutReturnPage.scala
+++ b/app/pages/aboutReturn/CheckAnswersAboutReturnPage.scala
@@ -24,5 +24,4 @@ case object CheckAnswersAboutReturnPage extends QuestionPage[String] {
   override def path: JsPath = JsPath \ toString
 
   override def toString: String = "checkAnswersAboutReturn"
-
 }

--- a/app/pages/aboutReturn/FullOrAbbreviatedReturnPage.scala
+++ b/app/pages/aboutReturn/FullOrAbbreviatedReturnPage.scala
@@ -46,6 +46,4 @@ case object FullOrAbbreviatedReturnPage extends QuestionPage[FullOrAbbreviatedRe
       p == FullOrAbbreviatedReturnPage)
   }
 
-  val reads = implicitly
-  val writes = implicitly
 }

--- a/app/pages/aboutReturn/FullOrAbbreviatedReturnPage.scala
+++ b/app/pages/aboutReturn/FullOrAbbreviatedReturnPage.scala
@@ -45,4 +45,7 @@ case object FullOrAbbreviatedReturnPage extends QuestionPage[FullOrAbbreviatedRe
       p == AgentNamePage ||
       p == FullOrAbbreviatedReturnPage)
   }
+
+  val reads = implicitly
+  val writes = implicitly
 }

--- a/app/pages/aboutReturn/ReportingCompanyAppointedPage.scala
+++ b/app/pages/aboutReturn/ReportingCompanyAppointedPage.scala
@@ -40,6 +40,4 @@ case object ReportingCompanyAppointedPage extends QuestionPage[Boolean] {
     }
   }
 
-  val reads = implicitly
-  val writes = implicitly
 }

--- a/app/pages/aboutReturn/ReportingCompanyAppointedPage.scala
+++ b/app/pages/aboutReturn/ReportingCompanyAppointedPage.scala
@@ -39,4 +39,7 @@ case object ReportingCompanyAppointedPage extends QuestionPage[Boolean] {
       }
     }
   }
+
+  val reads = implicitly
+  val writes = implicitly
 }

--- a/app/pages/aboutReturn/ReportingCompanyCTUTRPage.scala
+++ b/app/pages/aboutReturn/ReportingCompanyCTUTRPage.scala
@@ -24,4 +24,7 @@ case object ReportingCompanyCTUTRPage extends QuestionPage[String] {
   override def path: JsPath = JsPath \ toString
 
   override def toString: String = "reportingCompanyCTUTR"
+
+  val reads = implicitly
+  val writes = implicitly
 }

--- a/app/pages/aboutReturn/ReportingCompanyCTUTRPage.scala
+++ b/app/pages/aboutReturn/ReportingCompanyCTUTRPage.scala
@@ -25,6 +25,4 @@ case object ReportingCompanyCTUTRPage extends QuestionPage[String] {
 
   override def toString: String = "reportingCompanyCTUTR"
 
-  val reads = implicitly
-  val writes = implicitly
 }

--- a/app/pages/aboutReturn/ReportingCompanyCTUTRPage.scala
+++ b/app/pages/aboutReturn/ReportingCompanyCTUTRPage.scala
@@ -24,5 +24,4 @@ case object ReportingCompanyCTUTRPage extends QuestionPage[String] {
   override def path: JsPath = JsPath \ toString
 
   override def toString: String = "reportingCompanyCTUTR"
-
 }

--- a/app/pages/aboutReturn/ReportingCompanyNamePage.scala
+++ b/app/pages/aboutReturn/ReportingCompanyNamePage.scala
@@ -24,5 +24,4 @@ case object ReportingCompanyNamePage extends QuestionPage[String] {
   override def path: JsPath = JsPath \ toString
 
   override def toString: String = "reportingCompanyName"
-
 }

--- a/app/pages/aboutReturn/ReportingCompanyNamePage.scala
+++ b/app/pages/aboutReturn/ReportingCompanyNamePage.scala
@@ -25,6 +25,4 @@ case object ReportingCompanyNamePage extends QuestionPage[String] {
 
   override def toString: String = "reportingCompanyName"
 
-  val reads = implicitly
-  val writes = implicitly
 }

--- a/app/pages/aboutReturn/ReportingCompanyNamePage.scala
+++ b/app/pages/aboutReturn/ReportingCompanyNamePage.scala
@@ -24,4 +24,7 @@ case object ReportingCompanyNamePage extends QuestionPage[String] {
   override def path: JsPath = JsPath \ toString
 
   override def toString: String = "reportingCompanyName"
+
+  val reads = implicitly
+  val writes = implicitly
 }

--- a/app/pages/aboutReturn/ReportingCompanyRequiredPage.scala
+++ b/app/pages/aboutReturn/ReportingCompanyRequiredPage.scala
@@ -25,6 +25,4 @@ case object ReportingCompanyRequiredPage extends QuestionPage[Boolean] {
 
   override def toString: String = "reportingCompanyRequired"
 
-  val reads = implicitly
-  val writes = implicitly
 }

--- a/app/pages/aboutReturn/ReportingCompanyRequiredPage.scala
+++ b/app/pages/aboutReturn/ReportingCompanyRequiredPage.scala
@@ -24,4 +24,7 @@ case object ReportingCompanyRequiredPage extends QuestionPage[Boolean] {
   override def path: JsPath = JsPath \ toString
 
   override def toString: String = "reportingCompanyRequired"
+
+  val reads = implicitly
+  val writes = implicitly
 }

--- a/app/pages/aboutReturn/ReportingCompanyRequiredPage.scala
+++ b/app/pages/aboutReturn/ReportingCompanyRequiredPage.scala
@@ -24,5 +24,4 @@ case object ReportingCompanyRequiredPage extends QuestionPage[Boolean] {
   override def path: JsPath = JsPath \ toString
 
   override def toString: String = "reportingCompanyRequired"
-
 }

--- a/app/pages/aboutReturn/TellUsWhatHasChangedPage.scala
+++ b/app/pages/aboutReturn/TellUsWhatHasChangedPage.scala
@@ -23,5 +23,4 @@ case object TellUsWhatHasChangedPage extends QuestionPage[String] {
   override def path: JsPath = JsPath \ toString
 
   override def toString: String = "tellUsWhatHasChanged"
-
 }

--- a/app/pages/aboutReturn/TellUsWhatHasChangedPage.scala
+++ b/app/pages/aboutReturn/TellUsWhatHasChangedPage.scala
@@ -24,6 +24,4 @@ case object TellUsWhatHasChangedPage extends QuestionPage[String] {
 
   override def toString: String = "tellUsWhatHasChanged"
 
-  val reads = implicitly
-  val writes = implicitly
 }

--- a/app/pages/aboutReturn/TellUsWhatHasChangedPage.scala
+++ b/app/pages/aboutReturn/TellUsWhatHasChangedPage.scala
@@ -23,4 +23,7 @@ case object TellUsWhatHasChangedPage extends QuestionPage[String] {
   override def path: JsPath = JsPath \ toString
 
   override def toString: String = "tellUsWhatHasChanged"
+
+  val reads = implicitly
+  val writes = implicitly
 }

--- a/app/pages/checkTotals/ReviewNetTaxInterestPage.scala
+++ b/app/pages/checkTotals/ReviewNetTaxInterestPage.scala
@@ -24,5 +24,4 @@ case object ReviewNetTaxInterestPage extends QuestionPage[String] {
   override def path: JsPath = JsPath \ toString
 
   override def toString: String = "reviewNetTaxInterest"
-
 }

--- a/app/pages/checkTotals/ReviewNetTaxInterestPage.scala
+++ b/app/pages/checkTotals/ReviewNetTaxInterestPage.scala
@@ -25,6 +25,4 @@ case object ReviewNetTaxInterestPage extends QuestionPage[String] {
 
   override def toString: String = "reviewNetTaxInterest"
 
-  val reads = implicitly
-  val writes = implicitly
 }

--- a/app/pages/checkTotals/ReviewNetTaxInterestPage.scala
+++ b/app/pages/checkTotals/ReviewNetTaxInterestPage.scala
@@ -24,4 +24,7 @@ case object ReviewNetTaxInterestPage extends QuestionPage[String] {
   override def path: JsPath = JsPath \ toString
 
   override def toString: String = "reviewNetTaxInterest"
+
+  val reads = implicitly
+  val writes = implicitly
 }

--- a/app/pages/checkTotals/ReviewReactivationsPage.scala
+++ b/app/pages/checkTotals/ReviewReactivationsPage.scala
@@ -24,5 +24,4 @@ case object ReviewReactivationsPage extends QuestionPage[String] {
   override def path: JsPath = JsPath \ toString
 
   override def toString: String = "reviewReactivations"
-
 }

--- a/app/pages/checkTotals/ReviewReactivationsPage.scala
+++ b/app/pages/checkTotals/ReviewReactivationsPage.scala
@@ -25,6 +25,4 @@ case object ReviewReactivationsPage extends QuestionPage[String] {
 
   override def toString: String = "reviewReactivations"
 
-  val reads = implicitly
-  val writes = implicitly
 }

--- a/app/pages/checkTotals/ReviewReactivationsPage.scala
+++ b/app/pages/checkTotals/ReviewReactivationsPage.scala
@@ -24,4 +24,7 @@ case object ReviewReactivationsPage extends QuestionPage[String] {
   override def path: JsPath = JsPath \ toString
 
   override def toString: String = "reviewReactivations"
+
+  val reads = implicitly
+  val writes = implicitly
 }

--- a/app/pages/checkTotals/ReviewTaxEBITDAPage.scala
+++ b/app/pages/checkTotals/ReviewTaxEBITDAPage.scala
@@ -25,6 +25,4 @@ case object ReviewTaxEBITDAPage extends QuestionPage[String] {
 
   override def toString: String = "reviewTaxEBITDA"
 
-  val reads = implicitly
-  val writes = implicitly
 }

--- a/app/pages/checkTotals/ReviewTaxEBITDAPage.scala
+++ b/app/pages/checkTotals/ReviewTaxEBITDAPage.scala
@@ -24,4 +24,7 @@ case object ReviewTaxEBITDAPage extends QuestionPage[String] {
   override def path: JsPath = JsPath \ toString
 
   override def toString: String = "reviewTaxEBITDA"
+
+  val reads = implicitly
+  val writes = implicitly
 }

--- a/app/pages/checkTotals/ReviewTaxEBITDAPage.scala
+++ b/app/pages/checkTotals/ReviewTaxEBITDAPage.scala
@@ -24,5 +24,4 @@ case object ReviewTaxEBITDAPage extends QuestionPage[String] {
   override def path: JsPath = JsPath \ toString
 
   override def toString: String = "reviewTaxEBITDA"
-
 }

--- a/app/pages/elections/AddInvestorGroupPage.scala
+++ b/app/pages/elections/AddInvestorGroupPage.scala
@@ -23,5 +23,4 @@ case object AddInvestorGroupPage extends QuestionPage[Boolean] {
   override def path: JsPath = JsPath \ toString
 
   override def toString: String = "addInvestorGroup"
-
 }

--- a/app/pages/elections/AddInvestorGroupPage.scala
+++ b/app/pages/elections/AddInvestorGroupPage.scala
@@ -23,4 +23,7 @@ case object AddInvestorGroupPage extends QuestionPage[Boolean] {
   override def path: JsPath = JsPath \ toString
 
   override def toString: String = "addInvestorGroup"
+
+  val reads = implicitly
+  val writes = implicitly
 }

--- a/app/pages/elections/AddInvestorGroupPage.scala
+++ b/app/pages/elections/AddInvestorGroupPage.scala
@@ -24,6 +24,4 @@ case object AddInvestorGroupPage extends QuestionPage[Boolean] {
 
   override def toString: String = "addInvestorGroup"
 
-  val reads = implicitly
-  val writes = implicitly
 }

--- a/app/pages/elections/CheckAnswersElectionsPage.scala
+++ b/app/pages/elections/CheckAnswersElectionsPage.scala
@@ -24,5 +24,4 @@ case object CheckAnswersElectionsPage extends QuestionPage[String] {
   override def path: JsPath = JsPath \ toString
 
   override def toString: String = "checkAnswersElections"
-
 }

--- a/app/pages/elections/CheckAnswersElectionsPage.scala
+++ b/app/pages/elections/CheckAnswersElectionsPage.scala
@@ -24,4 +24,7 @@ case object CheckAnswersElectionsPage extends QuestionPage[String] {
   override def path: JsPath = JsPath \ toString
 
   override def toString: String = "checkAnswersElections"
+
+  val reads = implicitly
+  val writes = implicitly
 }

--- a/app/pages/elections/CheckAnswersElectionsPage.scala
+++ b/app/pages/elections/CheckAnswersElectionsPage.scala
@@ -25,6 +25,4 @@ case object CheckAnswersElectionsPage extends QuestionPage[String] {
 
   override def toString: String = "checkAnswersElections"
 
-  val reads = implicitly
-  val writes = implicitly
 }

--- a/app/pages/elections/ElectedGroupEBITDABeforePage.scala
+++ b/app/pages/elections/ElectedGroupEBITDABeforePage.scala
@@ -24,4 +24,7 @@ case object ElectedGroupEBITDABeforePage extends QuestionPage[Boolean] {
   override def path: JsPath = JsPath \ toString
 
   override def toString: String = "electedGroupEBITDABefore"
+
+  val reads = implicitly
+  val writes = implicitly
 }

--- a/app/pages/elections/ElectedGroupEBITDABeforePage.scala
+++ b/app/pages/elections/ElectedGroupEBITDABeforePage.scala
@@ -24,5 +24,4 @@ case object ElectedGroupEBITDABeforePage extends QuestionPage[Boolean] {
   override def path: JsPath = JsPath \ toString
 
   override def toString: String = "electedGroupEBITDABefore"
-
 }

--- a/app/pages/elections/ElectedGroupEBITDABeforePage.scala
+++ b/app/pages/elections/ElectedGroupEBITDABeforePage.scala
@@ -25,6 +25,4 @@ case object ElectedGroupEBITDABeforePage extends QuestionPage[Boolean] {
 
   override def toString: String = "electedGroupEBITDABefore"
 
-  val reads = implicitly
-  val writes = implicitly
 }

--- a/app/pages/elections/ElectedInterestAllowanceAlternativeCalcBeforePage.scala
+++ b/app/pages/elections/ElectedInterestAllowanceAlternativeCalcBeforePage.scala
@@ -24,4 +24,7 @@ case object ElectedInterestAllowanceAlternativeCalcBeforePage extends QuestionPa
   override def path: JsPath = JsPath \ toString
 
   override def toString: String = "electedInterestAllowanceAlternativeCalcBefore"
+
+  val reads = implicitly
+  val writes = implicitly
 }

--- a/app/pages/elections/ElectedInterestAllowanceAlternativeCalcBeforePage.scala
+++ b/app/pages/elections/ElectedInterestAllowanceAlternativeCalcBeforePage.scala
@@ -25,6 +25,4 @@ case object ElectedInterestAllowanceAlternativeCalcBeforePage extends QuestionPa
 
   override def toString: String = "electedInterestAllowanceAlternativeCalcBefore"
 
-  val reads = implicitly
-  val writes = implicitly
 }

--- a/app/pages/elections/ElectedInterestAllowanceAlternativeCalcBeforePage.scala
+++ b/app/pages/elections/ElectedInterestAllowanceAlternativeCalcBeforePage.scala
@@ -24,5 +24,4 @@ case object ElectedInterestAllowanceAlternativeCalcBeforePage extends QuestionPa
   override def path: JsPath = JsPath \ toString
 
   override def toString: String = "electedInterestAllowanceAlternativeCalcBefore"
-
 }

--- a/app/pages/elections/ElectedInterestAllowanceConsolidatedPshipBeforePage.scala
+++ b/app/pages/elections/ElectedInterestAllowanceConsolidatedPshipBeforePage.scala
@@ -25,6 +25,4 @@ case object ElectedInterestAllowanceConsolidatedPshipBeforePage extends Question
 
   override def toString: String = "electedInterestAllowanceConsolidatedPshipBefore"
 
-  val reads = implicitly
-  val writes = implicitly
 }

--- a/app/pages/elections/ElectedInterestAllowanceConsolidatedPshipBeforePage.scala
+++ b/app/pages/elections/ElectedInterestAllowanceConsolidatedPshipBeforePage.scala
@@ -24,4 +24,7 @@ case object ElectedInterestAllowanceConsolidatedPshipBeforePage extends Question
   override def path: JsPath = JsPath \ toString
 
   override def toString: String = "electedInterestAllowanceConsolidatedPshipBefore"
+
+  val reads = implicitly
+  val writes = implicitly
 }

--- a/app/pages/elections/ElectedInterestAllowanceConsolidatedPshipBeforePage.scala
+++ b/app/pages/elections/ElectedInterestAllowanceConsolidatedPshipBeforePage.scala
@@ -24,5 +24,4 @@ case object ElectedInterestAllowanceConsolidatedPshipBeforePage extends Question
   override def path: JsPath = JsPath \ toString
 
   override def toString: String = "electedInterestAllowanceConsolidatedPshipBefore"
-
 }

--- a/app/pages/elections/GroupEBITDAChargeableGainsElectionPage.scala
+++ b/app/pages/elections/GroupEBITDAChargeableGainsElectionPage.scala
@@ -25,6 +25,4 @@ case object GroupEBITDAChargeableGainsElectionPage extends QuestionPage[Boolean]
 
   override def toString: String = "groupEBITDAChargeableGainsElection"
 
-  val reads = implicitly
-  val writes = implicitly
 }

--- a/app/pages/elections/GroupEBITDAChargeableGainsElectionPage.scala
+++ b/app/pages/elections/GroupEBITDAChargeableGainsElectionPage.scala
@@ -24,5 +24,4 @@ case object GroupEBITDAChargeableGainsElectionPage extends QuestionPage[Boolean]
   override def path: JsPath = JsPath \ toString
 
   override def toString: String = "groupEBITDAChargeableGainsElection"
-
 }

--- a/app/pages/elections/GroupEBITDAChargeableGainsElectionPage.scala
+++ b/app/pages/elections/GroupEBITDAChargeableGainsElectionPage.scala
@@ -24,4 +24,7 @@ case object GroupEBITDAChargeableGainsElectionPage extends QuestionPage[Boolean]
   override def path: JsPath = JsPath \ toString
 
   override def toString: String = "groupEBITDAChargeableGainsElection"
+
+  val reads = implicitly
+  val writes = implicitly
 }

--- a/app/pages/elections/GroupRatioBlendedElectionPage.scala
+++ b/app/pages/elections/GroupRatioBlendedElectionPage.scala
@@ -24,4 +24,7 @@ case object GroupRatioBlendedElectionPage extends QuestionPage[Boolean] {
   override def path: JsPath = JsPath \ toString
 
   override def toString: String = "groupRatioBlendedElection"
+
+  val reads = implicitly
+  val writes = implicitly
 }

--- a/app/pages/elections/GroupRatioBlendedElectionPage.scala
+++ b/app/pages/elections/GroupRatioBlendedElectionPage.scala
@@ -24,5 +24,4 @@ case object GroupRatioBlendedElectionPage extends QuestionPage[Boolean] {
   override def path: JsPath = JsPath \ toString
 
   override def toString: String = "groupRatioBlendedElection"
-
 }

--- a/app/pages/elections/GroupRatioBlendedElectionPage.scala
+++ b/app/pages/elections/GroupRatioBlendedElectionPage.scala
@@ -25,6 +25,4 @@ case object GroupRatioBlendedElectionPage extends QuestionPage[Boolean] {
 
   override def toString: String = "groupRatioBlendedElection"
 
-  val reads = implicitly
-  val writes = implicitly
 }

--- a/app/pages/elections/GroupRatioElectionPage.scala
+++ b/app/pages/elections/GroupRatioElectionPage.scala
@@ -25,6 +25,4 @@ case object GroupRatioElectionPage extends QuestionPage[Boolean] {
 
   override def toString: String = "groupRatioElection"
 
-  val reads = implicitly
-  val writes = implicitly
 }

--- a/app/pages/elections/GroupRatioElectionPage.scala
+++ b/app/pages/elections/GroupRatioElectionPage.scala
@@ -24,5 +24,4 @@ case object GroupRatioElectionPage extends QuestionPage[Boolean] {
   override def path: JsPath = JsPath \ toString
 
   override def toString: String = "groupRatioElection"
-
 }

--- a/app/pages/elections/GroupRatioElectionPage.scala
+++ b/app/pages/elections/GroupRatioElectionPage.scala
@@ -24,4 +24,7 @@ case object GroupRatioElectionPage extends QuestionPage[Boolean] {
   override def path: JsPath = JsPath \ toString
 
   override def toString: String = "groupRatioElection"
+
+  val reads = implicitly
+  val writes = implicitly
 }

--- a/app/pages/elections/InterestAllowanceAlternativeCalcElectionPage.scala
+++ b/app/pages/elections/InterestAllowanceAlternativeCalcElectionPage.scala
@@ -24,4 +24,7 @@ case object InterestAllowanceAlternativeCalcElectionPage extends QuestionPage[Bo
   override def path: JsPath = JsPath \ toString
 
   override def toString: String = "interestAllowanceAlternativeCalcElection"
+
+  val reads = implicitly
+  val writes = implicitly
 }

--- a/app/pages/elections/InterestAllowanceAlternativeCalcElectionPage.scala
+++ b/app/pages/elections/InterestAllowanceAlternativeCalcElectionPage.scala
@@ -24,5 +24,4 @@ case object InterestAllowanceAlternativeCalcElectionPage extends QuestionPage[Bo
   override def path: JsPath = JsPath \ toString
 
   override def toString: String = "interestAllowanceAlternativeCalcElection"
-
 }

--- a/app/pages/elections/InterestAllowanceAlternativeCalcElectionPage.scala
+++ b/app/pages/elections/InterestAllowanceAlternativeCalcElectionPage.scala
@@ -25,6 +25,4 @@ case object InterestAllowanceAlternativeCalcElectionPage extends QuestionPage[Bo
 
   override def toString: String = "interestAllowanceAlternativeCalcElection"
 
-  val reads = implicitly
-  val writes = implicitly
 }

--- a/app/pages/elections/InterestAllowanceConsolidatedPshipElectionPage.scala
+++ b/app/pages/elections/InterestAllowanceConsolidatedPshipElectionPage.scala
@@ -24,5 +24,4 @@ case object InterestAllowanceConsolidatedPshipElectionPage extends QuestionPage[
   override def path: JsPath = JsPath \ toString
 
   override def toString: String = "interestAllowanceConsolidatedPshipElection"
-
 }

--- a/app/pages/elections/InterestAllowanceConsolidatedPshipElectionPage.scala
+++ b/app/pages/elections/InterestAllowanceConsolidatedPshipElectionPage.scala
@@ -24,4 +24,7 @@ case object InterestAllowanceConsolidatedPshipElectionPage extends QuestionPage[
   override def path: JsPath = JsPath \ toString
 
   override def toString: String = "interestAllowanceConsolidatedPshipElection"
+
+  val reads = implicitly
+  val writes = implicitly
 }

--- a/app/pages/elections/InterestAllowanceConsolidatedPshipElectionPage.scala
+++ b/app/pages/elections/InterestAllowanceConsolidatedPshipElectionPage.scala
@@ -25,6 +25,4 @@ case object InterestAllowanceConsolidatedPshipElectionPage extends QuestionPage[
 
   override def toString: String = "interestAllowanceConsolidatedPshipElection"
 
-  val reads = implicitly
-  val writes = implicitly
 }

--- a/app/pages/elections/InterestAllowanceNonConsolidatedInvestmentsElectionPage.scala
+++ b/app/pages/elections/InterestAllowanceNonConsolidatedInvestmentsElectionPage.scala
@@ -24,5 +24,4 @@ case object InterestAllowanceNonConsolidatedInvestmentsElectionPage extends Ques
   override def path: JsPath = JsPath \ toString
 
   override def toString: String = "interestAllowanceNonConsolidatedInvestmentsElection"
-
 }

--- a/app/pages/elections/InterestAllowanceNonConsolidatedInvestmentsElectionPage.scala
+++ b/app/pages/elections/InterestAllowanceNonConsolidatedInvestmentsElectionPage.scala
@@ -24,4 +24,7 @@ case object InterestAllowanceNonConsolidatedInvestmentsElectionPage extends Ques
   override def path: JsPath = JsPath \ toString
 
   override def toString: String = "interestAllowanceNonConsolidatedInvestmentsElection"
+
+  val reads = implicitly
+  val writes = implicitly
 }

--- a/app/pages/elections/InterestAllowanceNonConsolidatedInvestmentsElectionPage.scala
+++ b/app/pages/elections/InterestAllowanceNonConsolidatedInvestmentsElectionPage.scala
@@ -25,6 +25,4 @@ case object InterestAllowanceNonConsolidatedInvestmentsElectionPage extends Ques
 
   override def toString: String = "interestAllowanceNonConsolidatedInvestmentsElection"
 
-  val reads = implicitly
-  val writes = implicitly
 }

--- a/app/pages/elections/InvestmentNamePage.scala
+++ b/app/pages/elections/InvestmentNamePage.scala
@@ -23,4 +23,7 @@ case object InvestmentNamePage extends QuestionPage[String] {
   override def path: JsPath = JsPath \ toString
 
   override def toString: String = "investmentName"
+
+  val reads = implicitly
+  val writes = implicitly
 }

--- a/app/pages/elections/InvestmentNamePage.scala
+++ b/app/pages/elections/InvestmentNamePage.scala
@@ -24,6 +24,4 @@ case object InvestmentNamePage extends QuestionPage[String] {
 
   override def toString: String = "investmentName"
 
-  val reads = implicitly
-  val writes = implicitly
 }

--- a/app/pages/elections/InvestmentNamePage.scala
+++ b/app/pages/elections/InvestmentNamePage.scala
@@ -23,5 +23,4 @@ case object InvestmentNamePage extends QuestionPage[String] {
   override def path: JsPath = JsPath \ toString
 
   override def toString: String = "investmentName"
-
 }

--- a/app/pages/elections/InvestmentsDeletionConfirmationPage.scala
+++ b/app/pages/elections/InvestmentsDeletionConfirmationPage.scala
@@ -23,4 +23,7 @@ case object InvestmentsDeletionConfirmationPage extends QuestionPage[Boolean] {
   override def path: JsPath = JsPath \ toString
 
   override def toString: String = "investmentsDeletionConfirmation"
+
+  val reads = implicitly
+  val writes = implicitly
 }

--- a/app/pages/elections/InvestmentsDeletionConfirmationPage.scala
+++ b/app/pages/elections/InvestmentsDeletionConfirmationPage.scala
@@ -24,6 +24,4 @@ case object InvestmentsDeletionConfirmationPage extends QuestionPage[Boolean] {
 
   override def toString: String = "investmentsDeletionConfirmation"
 
-  val reads = implicitly
-  val writes = implicitly
 }

--- a/app/pages/elections/InvestmentsDeletionConfirmationPage.scala
+++ b/app/pages/elections/InvestmentsDeletionConfirmationPage.scala
@@ -23,5 +23,4 @@ case object InvestmentsDeletionConfirmationPage extends QuestionPage[Boolean] {
   override def path: JsPath = JsPath \ toString
 
   override def toString: String = "investmentsDeletionConfirmation"
-
 }

--- a/app/pages/elections/InvestmentsReviewAnswersListPage.scala
+++ b/app/pages/elections/InvestmentsReviewAnswersListPage.scala
@@ -24,4 +24,7 @@ case object InvestmentsReviewAnswersListPage extends QuestionPage[Boolean] {
   override def path: JsPath = JsPath \ toString
 
   override def toString: String = "investmentsReviewAnswersListPage"
+
+  val reads = implicitly
+  val writes = implicitly
 }

--- a/app/pages/elections/InvestmentsReviewAnswersListPage.scala
+++ b/app/pages/elections/InvestmentsReviewAnswersListPage.scala
@@ -25,6 +25,4 @@ case object InvestmentsReviewAnswersListPage extends QuestionPage[Boolean] {
 
   override def toString: String = "investmentsReviewAnswersListPage"
 
-  val reads = implicitly
-  val writes = implicitly
 }

--- a/app/pages/elections/InvestmentsReviewAnswersListPage.scala
+++ b/app/pages/elections/InvestmentsReviewAnswersListPage.scala
@@ -24,5 +24,4 @@ case object InvestmentsReviewAnswersListPage extends QuestionPage[Boolean] {
   override def path: JsPath = JsPath \ toString
 
   override def toString: String = "investmentsReviewAnswersListPage"
-
 }

--- a/app/pages/elections/InvestorGroupNamePage.scala
+++ b/app/pages/elections/InvestorGroupNamePage.scala
@@ -23,5 +23,4 @@ case object InvestorGroupNamePage extends QuestionPage[String] {
   override def path: JsPath = JsPath \ toString
 
   override def toString: String = "investorGroupName"
-
 }

--- a/app/pages/elections/InvestorGroupNamePage.scala
+++ b/app/pages/elections/InvestorGroupNamePage.scala
@@ -23,4 +23,7 @@ case object InvestorGroupNamePage extends QuestionPage[String] {
   override def path: JsPath = JsPath \ toString
 
   override def toString: String = "investorGroupName"
+
+  val reads = implicitly
+  val writes = implicitly
 }

--- a/app/pages/elections/InvestorGroupNamePage.scala
+++ b/app/pages/elections/InvestorGroupNamePage.scala
@@ -24,6 +24,4 @@ case object InvestorGroupNamePage extends QuestionPage[String] {
 
   override def toString: String = "investorGroupName"
 
-  val reads = implicitly
-  val writes = implicitly
 }

--- a/app/pages/elections/InvestorGroupsDeletionConfirmationPage.scala
+++ b/app/pages/elections/InvestorGroupsDeletionConfirmationPage.scala
@@ -23,5 +23,4 @@ case object InvestorGroupsDeletionConfirmationPage extends QuestionPage[Boolean]
   override def path: JsPath = JsPath \ toString
 
   override def toString: String = "investorGroupsDeletionConfirmation"
-
 }

--- a/app/pages/elections/InvestorGroupsDeletionConfirmationPage.scala
+++ b/app/pages/elections/InvestorGroupsDeletionConfirmationPage.scala
@@ -23,4 +23,7 @@ case object InvestorGroupsDeletionConfirmationPage extends QuestionPage[Boolean]
   override def path: JsPath = JsPath \ toString
 
   override def toString: String = "investorGroupsDeletionConfirmation"
+
+  val reads = implicitly
+  val writes = implicitly
 }

--- a/app/pages/elections/InvestorGroupsDeletionConfirmationPage.scala
+++ b/app/pages/elections/InvestorGroupsDeletionConfirmationPage.scala
@@ -24,6 +24,4 @@ case object InvestorGroupsDeletionConfirmationPage extends QuestionPage[Boolean]
 
   override def toString: String = "investorGroupsDeletionConfirmation"
 
-  val reads = implicitly
-  val writes = implicitly
 }

--- a/app/pages/elections/InvestorGroupsPage.scala
+++ b/app/pages/elections/InvestorGroupsPage.scala
@@ -26,6 +26,4 @@ case object InvestorGroupsPage extends QuestionPage[InvestorGroupModel] {
 
   override def toString: String = "investorGroups"
 
-  val reads = implicitly
-  val writes = implicitly
 }

--- a/app/pages/elections/InvestorGroupsPage.scala
+++ b/app/pages/elections/InvestorGroupsPage.scala
@@ -25,5 +25,4 @@ case object InvestorGroupsPage extends QuestionPage[InvestorGroupModel] {
   override def path: JsPath = JsPath \ toString
 
   override def toString: String = "investorGroups"
-
 }

--- a/app/pages/elections/InvestorGroupsPage.scala
+++ b/app/pages/elections/InvestorGroupsPage.scala
@@ -25,4 +25,7 @@ case object InvestorGroupsPage extends QuestionPage[InvestorGroupModel] {
   override def path: JsPath = JsPath \ toString
 
   override def toString: String = "investorGroups"
+
+  val reads = implicitly
+  val writes = implicitly
 }

--- a/app/pages/elections/InvestorRatioMethodPage.scala
+++ b/app/pages/elections/InvestorRatioMethodPage.scala
@@ -23,4 +23,7 @@ case object InvestorRatioMethodPage extends QuestionPage[Boolean] {
   override def path: JsPath = JsPath \ toString
 
   override def toString: String = "investorRatioMethod"
+
+  val reads = implicitly
+  val writes = implicitly
 }

--- a/app/pages/elections/InvestorRatioMethodPage.scala
+++ b/app/pages/elections/InvestorRatioMethodPage.scala
@@ -24,6 +24,4 @@ case object InvestorRatioMethodPage extends QuestionPage[Boolean] {
 
   override def toString: String = "investorRatioMethod"
 
-  val reads = implicitly
-  val writes = implicitly
 }

--- a/app/pages/elections/InvestorRatioMethodPage.scala
+++ b/app/pages/elections/InvestorRatioMethodPage.scala
@@ -23,5 +23,4 @@ case object InvestorRatioMethodPage extends QuestionPage[Boolean] {
   override def path: JsPath = JsPath \ toString
 
   override def toString: String = "investorRatioMethod"
-
 }

--- a/app/pages/elections/IsUkPartnershipPage.scala
+++ b/app/pages/elections/IsUkPartnershipPage.scala
@@ -23,4 +23,7 @@ case object IsUkPartnershipPage extends QuestionPage[Boolean] {
   override def path: JsPath = JsPath \ toString
 
   override def toString: String = "isUkPartnership"
+
+  val reads = implicitly
+  val writes = implicitly
 }

--- a/app/pages/elections/IsUkPartnershipPage.scala
+++ b/app/pages/elections/IsUkPartnershipPage.scala
@@ -23,5 +23,4 @@ case object IsUkPartnershipPage extends QuestionPage[Boolean] {
   override def path: JsPath = JsPath \ toString
 
   override def toString: String = "isUkPartnership"
-
 }

--- a/app/pages/elections/IsUkPartnershipPage.scala
+++ b/app/pages/elections/IsUkPartnershipPage.scala
@@ -24,6 +24,4 @@ case object IsUkPartnershipPage extends QuestionPage[Boolean] {
 
   override def toString: String = "isUkPartnership"
 
-  val reads = implicitly
-  val writes = implicitly
 }

--- a/app/pages/elections/OtherInvestorGroupElectionsPage.scala
+++ b/app/pages/elections/OtherInvestorGroupElectionsPage.scala
@@ -24,5 +24,4 @@ case object OtherInvestorGroupElectionsPage extends QuestionPage[Set[OtherInvest
   override def path: JsPath = JsPath \ toString
 
   override def toString: String = "otherInvestorGroupElections"
-
 }

--- a/app/pages/elections/OtherInvestorGroupElectionsPage.scala
+++ b/app/pages/elections/OtherInvestorGroupElectionsPage.scala
@@ -24,4 +24,7 @@ case object OtherInvestorGroupElectionsPage extends QuestionPage[Set[OtherInvest
   override def path: JsPath = JsPath \ toString
 
   override def toString: String = "otherInvestorGroupElections"
+
+  val reads = implicitly
+  val writes = implicitly
 }

--- a/app/pages/elections/OtherInvestorGroupElectionsPage.scala
+++ b/app/pages/elections/OtherInvestorGroupElectionsPage.scala
@@ -25,6 +25,4 @@ case object OtherInvestorGroupElectionsPage extends QuestionPage[Set[OtherInvest
 
   override def toString: String = "otherInvestorGroupElections"
 
-  val reads = implicitly
-  val writes = implicitly
 }

--- a/app/pages/elections/PartnershipDeletionConfirmationPage.scala
+++ b/app/pages/elections/PartnershipDeletionConfirmationPage.scala
@@ -23,4 +23,7 @@ case object PartnershipDeletionConfirmationPage extends QuestionPage[Boolean] {
   override def path: JsPath = JsPath \ toString
 
   override def toString: String = "partnershipDeletionConfirmation"
+
+  val reads = implicitly
+  val writes = implicitly
 }

--- a/app/pages/elections/PartnershipDeletionConfirmationPage.scala
+++ b/app/pages/elections/PartnershipDeletionConfirmationPage.scala
@@ -23,5 +23,4 @@ case object PartnershipDeletionConfirmationPage extends QuestionPage[Boolean] {
   override def path: JsPath = JsPath \ toString
 
   override def toString: String = "partnershipDeletionConfirmation"
-
 }

--- a/app/pages/elections/PartnershipDeletionConfirmationPage.scala
+++ b/app/pages/elections/PartnershipDeletionConfirmationPage.scala
@@ -24,6 +24,4 @@ case object PartnershipDeletionConfirmationPage extends QuestionPage[Boolean] {
 
   override def toString: String = "partnershipDeletionConfirmation"
 
-  val reads = implicitly
-  val writes = implicitly
 }

--- a/app/pages/elections/PartnershipNamePage.scala
+++ b/app/pages/elections/PartnershipNamePage.scala
@@ -24,6 +24,4 @@ case object PartnershipNamePage extends QuestionPage[String] {
 
   override def toString: String = "name"
 
-  val reads = implicitly
-  val writes = implicitly
 }

--- a/app/pages/elections/PartnershipNamePage.scala
+++ b/app/pages/elections/PartnershipNamePage.scala
@@ -23,5 +23,4 @@ case object PartnershipNamePage extends QuestionPage[String] {
   override def path: JsPath = JsPath \ toString
 
   override def toString: String = "name"
-
 }

--- a/app/pages/elections/PartnershipNamePage.scala
+++ b/app/pages/elections/PartnershipNamePage.scala
@@ -23,4 +23,7 @@ case object PartnershipNamePage extends QuestionPage[String] {
   override def path: JsPath = JsPath \ toString
 
   override def toString: String = "name"
+
+  val reads = implicitly
+  val writes = implicitly
 }

--- a/app/pages/elections/PartnershipSAUTRPage.scala
+++ b/app/pages/elections/PartnershipSAUTRPage.scala
@@ -23,5 +23,4 @@ case object PartnershipSAUTRPage extends QuestionPage[String] {
   override def path: JsPath = JsPath \ toString
 
   override def toString: String = "partnershipSAUTR"
-
 }

--- a/app/pages/elections/PartnershipSAUTRPage.scala
+++ b/app/pages/elections/PartnershipSAUTRPage.scala
@@ -23,4 +23,7 @@ case object PartnershipSAUTRPage extends QuestionPage[String] {
   override def path: JsPath = JsPath \ toString
 
   override def toString: String = "partnershipSAUTR"
+
+  val reads = implicitly
+  val writes = implicitly
 }

--- a/app/pages/elections/PartnershipSAUTRPage.scala
+++ b/app/pages/elections/PartnershipSAUTRPage.scala
@@ -24,6 +24,4 @@ case object PartnershipSAUTRPage extends QuestionPage[String] {
 
   override def toString: String = "partnershipSAUTR"
 
-  val reads = implicitly
-  val writes = implicitly
 }

--- a/app/pages/elections/PartnershipsPage.scala
+++ b/app/pages/elections/PartnershipsPage.scala
@@ -25,5 +25,4 @@ case object PartnershipsPage extends QuestionPage[PartnershipModel] {
   override def path: JsPath = JsPath \ toString
 
   override def toString: String = "partnershipGroups"
-
 }

--- a/app/pages/elections/PartnershipsPage.scala
+++ b/app/pages/elections/PartnershipsPage.scala
@@ -25,4 +25,7 @@ case object PartnershipsPage extends QuestionPage[PartnershipModel] {
   override def path: JsPath = JsPath \ toString
 
   override def toString: String = "partnershipGroups"
+
+  val reads = implicitly
+  val writes = implicitly
 }

--- a/app/pages/elections/PartnershipsPage.scala
+++ b/app/pages/elections/PartnershipsPage.scala
@@ -26,6 +26,4 @@ case object PartnershipsPage extends QuestionPage[PartnershipModel] {
 
   override def toString: String = "partnershipGroups"
 
-  val reads = implicitly
-  val writes = implicitly
 }

--- a/app/pages/elections/PartnershipsReviewAnswersListPage.scala
+++ b/app/pages/elections/PartnershipsReviewAnswersListPage.scala
@@ -23,4 +23,7 @@ case object PartnershipsReviewAnswersListPage extends QuestionPage[Boolean] {
   override def path: JsPath = JsPath \ toString
 
   override def toString: String = "partnershipsReviewAnswersList"
+
+  val reads = implicitly
+  val writes = implicitly
 }

--- a/app/pages/elections/PartnershipsReviewAnswersListPage.scala
+++ b/app/pages/elections/PartnershipsReviewAnswersListPage.scala
@@ -23,5 +23,4 @@ case object PartnershipsReviewAnswersListPage extends QuestionPage[Boolean] {
   override def path: JsPath = JsPath \ toString
 
   override def toString: String = "partnershipsReviewAnswersList"
-
 }

--- a/app/pages/elections/PartnershipsReviewAnswersListPage.scala
+++ b/app/pages/elections/PartnershipsReviewAnswersListPage.scala
@@ -24,6 +24,4 @@ case object PartnershipsReviewAnswersListPage extends QuestionPage[Boolean] {
 
   override def toString: String = "partnershipsReviewAnswersList"
 
-  val reads = implicitly
-  val writes = implicitly
 }

--- a/app/pages/elections/QICElectionPage.scala
+++ b/app/pages/elections/QICElectionPage.scala
@@ -23,5 +23,4 @@ case object QICElectionPage extends QuestionPage[Boolean] {
   override def path: JsPath = JsPath \ toString
 
   override def toString: String = "qICElectionPage"
-
 }

--- a/app/pages/elections/QICElectionPage.scala
+++ b/app/pages/elections/QICElectionPage.scala
@@ -24,6 +24,4 @@ case object QICElectionPage extends QuestionPage[Boolean] {
 
   override def toString: String = "qICElectionPage"
 
-  val reads = implicitly
-  val writes = implicitly
 }

--- a/app/pages/elections/QICElectionPage.scala
+++ b/app/pages/elections/QICElectionPage.scala
@@ -23,4 +23,7 @@ case object QICElectionPage extends QuestionPage[Boolean] {
   override def path: JsPath = JsPath \ toString
 
   override def toString: String = "qICElectionPage"
+
+  val reads = implicitly
+  val writes = implicitly
 }

--- a/app/pages/groupLevelInformation/CheckAnswersGroupLevelPage.scala
+++ b/app/pages/groupLevelInformation/CheckAnswersGroupLevelPage.scala
@@ -24,4 +24,7 @@ case object CheckAnswersGroupLevelPage extends QuestionPage[String] {
   override def path: JsPath = JsPath \ toString
 
   override def toString: String = "checkAnswersGroupLevel"
+
+  val reads = implicitly
+  val writes = implicitly
 }

--- a/app/pages/groupLevelInformation/CheckAnswersGroupLevelPage.scala
+++ b/app/pages/groupLevelInformation/CheckAnswersGroupLevelPage.scala
@@ -24,5 +24,4 @@ case object CheckAnswersGroupLevelPage extends QuestionPage[String] {
   override def path: JsPath = JsPath \ toString
 
   override def toString: String = "checkAnswersGroupLevel"
-
 }

--- a/app/pages/groupLevelInformation/CheckAnswersGroupLevelPage.scala
+++ b/app/pages/groupLevelInformation/CheckAnswersGroupLevelPage.scala
@@ -25,6 +25,4 @@ case object CheckAnswersGroupLevelPage extends QuestionPage[String] {
 
   override def toString: String = "checkAnswersGroupLevel"
 
-  val reads = implicitly
-  val writes = implicitly
 }

--- a/app/pages/groupLevelInformation/DisallowedAmountPage.scala
+++ b/app/pages/groupLevelInformation/DisallowedAmountPage.scala
@@ -24,6 +24,4 @@ case object DisallowedAmountPage extends QuestionPage[BigDecimal] {
 
   override def toString: String = "disallowedAmount"
 
-  val reads = implicitly
-  val writes = implicitly
 }

--- a/app/pages/groupLevelInformation/DisallowedAmountPage.scala
+++ b/app/pages/groupLevelInformation/DisallowedAmountPage.scala
@@ -23,5 +23,4 @@ case object DisallowedAmountPage extends QuestionPage[BigDecimal] {
   override def path: JsPath = JsPath \ toString
 
   override def toString: String = "disallowedAmount"
-
 }

--- a/app/pages/groupLevelInformation/DisallowedAmountPage.scala
+++ b/app/pages/groupLevelInformation/DisallowedAmountPage.scala
@@ -23,4 +23,7 @@ case object DisallowedAmountPage extends QuestionPage[BigDecimal] {
   override def path: JsPath = JsPath \ toString
 
   override def toString: String = "disallowedAmount"
+
+  val reads = implicitly
+  val writes = implicitly
 }

--- a/app/pages/groupLevelInformation/EnterANGIEPage.scala
+++ b/app/pages/groupLevelInformation/EnterANGIEPage.scala
@@ -23,5 +23,4 @@ case object EnterANGIEPage extends QuestionPage[BigDecimal] {
   override def path: JsPath = JsPath \ toString
 
   override def toString: String = "enterANGIE"
-
 }

--- a/app/pages/groupLevelInformation/EnterANGIEPage.scala
+++ b/app/pages/groupLevelInformation/EnterANGIEPage.scala
@@ -23,4 +23,7 @@ case object EnterANGIEPage extends QuestionPage[BigDecimal] {
   override def path: JsPath = JsPath \ toString
 
   override def toString: String = "enterANGIE"
+
+  val reads = implicitly
+  val writes = implicitly
 }

--- a/app/pages/groupLevelInformation/EnterANGIEPage.scala
+++ b/app/pages/groupLevelInformation/EnterANGIEPage.scala
@@ -24,6 +24,4 @@ case object EnterANGIEPage extends QuestionPage[BigDecimal] {
 
   override def toString: String = "enterANGIE"
 
-  val reads = implicitly
-  val writes = implicitly
 }

--- a/app/pages/groupLevelInformation/EnterQNGIEPage.scala
+++ b/app/pages/groupLevelInformation/EnterQNGIEPage.scala
@@ -23,4 +23,7 @@ case object EnterQNGIEPage extends QuestionPage[BigDecimal] {
   override def path: JsPath = JsPath \ toString
 
   override def toString: String = "enterQNGIE"
+
+  val reads = implicitly
+  val writes = implicitly
 }

--- a/app/pages/groupLevelInformation/EnterQNGIEPage.scala
+++ b/app/pages/groupLevelInformation/EnterQNGIEPage.scala
@@ -23,5 +23,4 @@ case object EnterQNGIEPage extends QuestionPage[BigDecimal] {
   override def path: JsPath = JsPath \ toString
 
   override def toString: String = "enterQNGIE"
-
 }

--- a/app/pages/groupLevelInformation/EnterQNGIEPage.scala
+++ b/app/pages/groupLevelInformation/EnterQNGIEPage.scala
@@ -24,6 +24,4 @@ case object EnterQNGIEPage extends QuestionPage[BigDecimal] {
 
   override def toString: String = "enterQNGIE"
 
-  val reads = implicitly
-  val writes = implicitly
 }

--- a/app/pages/groupLevelInformation/GroupEBITDAPage.scala
+++ b/app/pages/groupLevelInformation/GroupEBITDAPage.scala
@@ -23,5 +23,4 @@ case object GroupEBITDAPage extends QuestionPage[BigDecimal] {
   override def path: JsPath = JsPath \ toString
 
   override def toString: String = "groupEBITDA"
-
 }

--- a/app/pages/groupLevelInformation/GroupEBITDAPage.scala
+++ b/app/pages/groupLevelInformation/GroupEBITDAPage.scala
@@ -24,6 +24,4 @@ case object GroupEBITDAPage extends QuestionPage[BigDecimal] {
 
   override def toString: String = "groupEBITDA"
 
-  val reads = implicitly
-  val writes = implicitly
 }

--- a/app/pages/groupLevelInformation/GroupEBITDAPage.scala
+++ b/app/pages/groupLevelInformation/GroupEBITDAPage.scala
@@ -23,4 +23,7 @@ case object GroupEBITDAPage extends QuestionPage[BigDecimal] {
   override def path: JsPath = JsPath \ toString
 
   override def toString: String = "groupEBITDA"
+
+  val reads = implicitly
+  val writes = implicitly
 }

--- a/app/pages/groupLevelInformation/GroupInterestAllowancePage.scala
+++ b/app/pages/groupLevelInformation/GroupInterestAllowancePage.scala
@@ -24,4 +24,7 @@ case object GroupInterestAllowancePage extends QuestionPage[BigDecimal] {
   override def path: JsPath = JsPath \ toString
 
   override def toString: String = "groupInterestAllowance"
+
+  val reads = implicitly
+  val writes = implicitly
 }

--- a/app/pages/groupLevelInformation/GroupInterestAllowancePage.scala
+++ b/app/pages/groupLevelInformation/GroupInterestAllowancePage.scala
@@ -25,6 +25,4 @@ case object GroupInterestAllowancePage extends QuestionPage[BigDecimal] {
 
   override def toString: String = "groupInterestAllowance"
 
-  val reads = implicitly
-  val writes = implicitly
 }

--- a/app/pages/groupLevelInformation/GroupInterestAllowancePage.scala
+++ b/app/pages/groupLevelInformation/GroupInterestAllowancePage.scala
@@ -24,5 +24,4 @@ case object GroupInterestAllowancePage extends QuestionPage[BigDecimal] {
   override def path: JsPath = JsPath \ toString
 
   override def toString: String = "groupInterestAllowance"
-
 }

--- a/app/pages/groupLevelInformation/GroupInterestCapacityPage.scala
+++ b/app/pages/groupLevelInformation/GroupInterestCapacityPage.scala
@@ -24,4 +24,7 @@ case object GroupInterestCapacityPage extends QuestionPage[BigDecimal] {
   override def path: JsPath = JsPath \ toString
 
   override def toString: String = "groupInterestCapacity"
+
+  val reads = implicitly
+  val writes = implicitly
 }

--- a/app/pages/groupLevelInformation/GroupInterestCapacityPage.scala
+++ b/app/pages/groupLevelInformation/GroupInterestCapacityPage.scala
@@ -25,6 +25,4 @@ case object GroupInterestCapacityPage extends QuestionPage[BigDecimal] {
 
   override def toString: String = "groupInterestCapacity"
 
-  val reads = implicitly
-  val writes = implicitly
 }

--- a/app/pages/groupLevelInformation/GroupInterestCapacityPage.scala
+++ b/app/pages/groupLevelInformation/GroupInterestCapacityPage.scala
@@ -24,5 +24,4 @@ case object GroupInterestCapacityPage extends QuestionPage[BigDecimal] {
   override def path: JsPath = JsPath \ toString
 
   override def toString: String = "groupInterestCapacity"
-
 }

--- a/app/pages/groupLevelInformation/GroupRatioPercentagePage.scala
+++ b/app/pages/groupLevelInformation/GroupRatioPercentagePage.scala
@@ -23,4 +23,7 @@ case object GroupRatioPercentagePage extends QuestionPage[BigDecimal] {
   override def path: JsPath = JsPath \ toString
 
   override def toString: String = "groupRatioPercentage"
+
+  val reads = implicitly
+  val writes = implicitly
 }

--- a/app/pages/groupLevelInformation/GroupRatioPercentagePage.scala
+++ b/app/pages/groupLevelInformation/GroupRatioPercentagePage.scala
@@ -24,6 +24,4 @@ case object GroupRatioPercentagePage extends QuestionPage[BigDecimal] {
 
   override def toString: String = "groupRatioPercentage"
 
-  val reads = implicitly
-  val writes = implicitly
 }

--- a/app/pages/groupLevelInformation/GroupRatioPercentagePage.scala
+++ b/app/pages/groupLevelInformation/GroupRatioPercentagePage.scala
@@ -23,5 +23,4 @@ case object GroupRatioPercentagePage extends QuestionPage[BigDecimal] {
   override def path: JsPath = JsPath \ toString
 
   override def toString: String = "groupRatioPercentage"
-
 }

--- a/app/pages/groupLevelInformation/GroupSubjectToReactivationsPage.scala
+++ b/app/pages/groupLevelInformation/GroupSubjectToReactivationsPage.scala
@@ -35,6 +35,4 @@ case object GroupSubjectToReactivationsPage extends QuestionPage[Boolean] {
     }
   }
 
-  val reads = implicitly
-  val writes = implicitly
 }

--- a/app/pages/groupLevelInformation/GroupSubjectToReactivationsPage.scala
+++ b/app/pages/groupLevelInformation/GroupSubjectToReactivationsPage.scala
@@ -34,4 +34,7 @@ case object GroupSubjectToReactivationsPage extends QuestionPage[Boolean] {
       case _ => super.cleanup(value, userAnswers)
     }
   }
+
+  val reads = implicitly
+  val writes = implicitly
 }

--- a/app/pages/groupLevelInformation/GroupSubjectToRestrictionsPage.scala
+++ b/app/pages/groupLevelInformation/GroupSubjectToRestrictionsPage.scala
@@ -40,6 +40,4 @@ case object GroupSubjectToRestrictionsPage extends QuestionPage[Boolean] {
     }
   }
 
-  val reads = implicitly
-  val writes = implicitly
 }

--- a/app/pages/groupLevelInformation/GroupSubjectToRestrictionsPage.scala
+++ b/app/pages/groupLevelInformation/GroupSubjectToRestrictionsPage.scala
@@ -39,4 +39,7 @@ case object GroupSubjectToRestrictionsPage extends QuestionPage[Boolean] {
       case _ => super.cleanup(value, userAnswers)
     }
   }
+
+  val reads = implicitly
+  val writes = implicitly
 }

--- a/app/pages/groupLevelInformation/InterestAllowanceBroughtForwardPage.scala
+++ b/app/pages/groupLevelInformation/InterestAllowanceBroughtForwardPage.scala
@@ -25,6 +25,4 @@ case object InterestAllowanceBroughtForwardPage extends QuestionPage[BigDecimal]
 
   override def toString: String = "interestAllowanceBroughtForward"
 
-  val reads = implicitly
-  val writes = implicitly
 }

--- a/app/pages/groupLevelInformation/InterestAllowanceBroughtForwardPage.scala
+++ b/app/pages/groupLevelInformation/InterestAllowanceBroughtForwardPage.scala
@@ -24,5 +24,4 @@ case object InterestAllowanceBroughtForwardPage extends QuestionPage[BigDecimal]
   override def path: JsPath = JsPath \ toString
 
   override def toString: String = "interestAllowanceBroughtForward"
-
 }

--- a/app/pages/groupLevelInformation/InterestAllowanceBroughtForwardPage.scala
+++ b/app/pages/groupLevelInformation/InterestAllowanceBroughtForwardPage.scala
@@ -24,4 +24,7 @@ case object InterestAllowanceBroughtForwardPage extends QuestionPage[BigDecimal]
   override def path: JsPath = JsPath \ toString
 
   override def toString: String = "interestAllowanceBroughtForward"
+
+  val reads = implicitly
+  val writes = implicitly
 }

--- a/app/pages/groupLevelInformation/InterestReactivationsCapPage.scala
+++ b/app/pages/groupLevelInformation/InterestReactivationsCapPage.scala
@@ -25,6 +25,4 @@ case object InterestReactivationsCapPage extends QuestionPage[BigDecimal] {
 
   override def toString: String = "interestReactivationsCap"
 
-  val reads = implicitly
-  val writes = implicitly
 }

--- a/app/pages/groupLevelInformation/InterestReactivationsCapPage.scala
+++ b/app/pages/groupLevelInformation/InterestReactivationsCapPage.scala
@@ -24,4 +24,7 @@ case object InterestReactivationsCapPage extends QuestionPage[BigDecimal] {
   override def path: JsPath = JsPath \ toString
 
   override def toString: String = "interestReactivationsCap"
+
+  val reads = implicitly
+  val writes = implicitly
 }

--- a/app/pages/groupLevelInformation/InterestReactivationsCapPage.scala
+++ b/app/pages/groupLevelInformation/InterestReactivationsCapPage.scala
@@ -24,5 +24,4 @@ case object InterestReactivationsCapPage extends QuestionPage[BigDecimal] {
   override def path: JsPath = JsPath \ toString
 
   override def toString: String = "interestReactivationsCap"
-
 }

--- a/app/pages/groupLevelInformation/ReturnContainEstimatesPage.scala
+++ b/app/pages/groupLevelInformation/ReturnContainEstimatesPage.scala
@@ -25,6 +25,4 @@ case object ReturnContainEstimatesPage extends QuestionPage[Boolean] {
 
   override def toString: String = "returnContainEstimates"
 
-  val reads = implicitly
-  val writes = implicitly
 }

--- a/app/pages/groupLevelInformation/ReturnContainEstimatesPage.scala
+++ b/app/pages/groupLevelInformation/ReturnContainEstimatesPage.scala
@@ -24,4 +24,7 @@ case object ReturnContainEstimatesPage extends QuestionPage[Boolean] {
   override def path: JsPath = JsPath \ toString
 
   override def toString: String = "returnContainEstimates"
+
+  val reads = implicitly
+  val writes = implicitly
 }

--- a/app/pages/groupLevelInformation/ReturnContainEstimatesPage.scala
+++ b/app/pages/groupLevelInformation/ReturnContainEstimatesPage.scala
@@ -24,5 +24,4 @@ case object ReturnContainEstimatesPage extends QuestionPage[Boolean] {
   override def path: JsPath = JsPath \ toString
 
   override def toString: String = "returnContainEstimates"
-
 }

--- a/app/pages/groupLevelInformation/RevisingReturnPage.scala
+++ b/app/pages/groupLevelInformation/RevisingReturnPage.scala
@@ -39,4 +39,7 @@ case object RevisingReturnPage extends QuestionPage[Boolean] {
       }
     }
   }
+
+  val reads = implicitly
+  val writes = implicitly
 }

--- a/app/pages/groupLevelInformation/RevisingReturnPage.scala
+++ b/app/pages/groupLevelInformation/RevisingReturnPage.scala
@@ -40,6 +40,4 @@ case object RevisingReturnPage extends QuestionPage[Boolean] {
     }
   }
 
-  val reads = implicitly
-  val writes = implicitly
 }

--- a/app/pages/reviewAndComplete/ReviewAndCompletePage.scala
+++ b/app/pages/reviewAndComplete/ReviewAndCompletePage.scala
@@ -24,4 +24,7 @@ case object ReviewAndCompletePage extends QuestionPage[ReviewAndCompleteModel]{
   override def toString: String = "reviewAndComplete"
 
   override def path: JsPath = JsPath \ toString
+
+  val reads = implicitly
+  val writes = implicitly
 }

--- a/app/pages/reviewAndComplete/ReviewAndCompletePage.scala
+++ b/app/pages/reviewAndComplete/ReviewAndCompletePage.scala
@@ -15,9 +15,12 @@
  */
 
 package pages.reviewAndComplete
+
+import models.returnModels.ReviewAndCompleteModel._
 import models.returnModels.ReviewAndCompleteModel
 import pages.QuestionPage
 import play.api.libs.json.JsPath
+import play.api.libs.json._
 
 case object ReviewAndCompletePage extends QuestionPage[ReviewAndCompleteModel]{
 
@@ -25,6 +28,4 @@ case object ReviewAndCompletePage extends QuestionPage[ReviewAndCompleteModel]{
 
   override def path: JsPath = JsPath \ toString
 
-  val reads = implicitly
-  val writes = implicitly
 }

--- a/app/pages/ukCompanies/AddAnReactivationQueryPage.scala
+++ b/app/pages/ukCompanies/AddAnReactivationQueryPage.scala
@@ -24,6 +24,4 @@ case object AddAnReactivationQueryPage extends QuestionPage[Boolean] {
 
   override def toString: String = "addAnReactivationQuery"
 
-  val reads = implicitly
-  val writes = implicitly
 }

--- a/app/pages/ukCompanies/AddAnReactivationQueryPage.scala
+++ b/app/pages/ukCompanies/AddAnReactivationQueryPage.scala
@@ -23,5 +23,4 @@ case object AddAnReactivationQueryPage extends QuestionPage[Boolean] {
   override def path: JsPath = JsPath \ toString
 
   override def toString: String = "addAnReactivationQuery"
-
 }

--- a/app/pages/ukCompanies/AddAnReactivationQueryPage.scala
+++ b/app/pages/ukCompanies/AddAnReactivationQueryPage.scala
@@ -23,4 +23,7 @@ case object AddAnReactivationQueryPage extends QuestionPage[Boolean] {
   override def path: JsPath = JsPath \ toString
 
   override def toString: String = "addAnReactivationQuery"
+
+  val reads = implicitly
+  val writes = implicitly
 }

--- a/app/pages/ukCompanies/AddRestrictionPage.scala
+++ b/app/pages/ukCompanies/AddRestrictionPage.scala
@@ -23,5 +23,4 @@ case object AddRestrictionPage extends QuestionPage[Boolean] {
   override def path: JsPath = JsPath \ toString
 
   override def toString: String = "addRestriction"
-
 }

--- a/app/pages/ukCompanies/AddRestrictionPage.scala
+++ b/app/pages/ukCompanies/AddRestrictionPage.scala
@@ -24,6 +24,4 @@ case object AddRestrictionPage extends QuestionPage[Boolean] {
 
   override def toString: String = "addRestriction"
 
-  val reads = implicitly
-  val writes = implicitly
 }

--- a/app/pages/ukCompanies/AddRestrictionPage.scala
+++ b/app/pages/ukCompanies/AddRestrictionPage.scala
@@ -23,4 +23,7 @@ case object AddRestrictionPage extends QuestionPage[Boolean] {
   override def path: JsPath = JsPath \ toString
 
   override def toString: String = "addRestriction"
+
+  val reads = implicitly
+  val writes = implicitly
 }

--- a/app/pages/ukCompanies/CheckAnswersUkCompanyPage.scala
+++ b/app/pages/ukCompanies/CheckAnswersUkCompanyPage.scala
@@ -23,4 +23,7 @@ case object CheckAnswersUkCompanyPage extends QuestionPage[String] {
   override def path: JsPath = JsPath \ toString
 
   override def toString: String = "checkAnswersUkCompany"
+
+  val reads = implicitly
+  val writes = implicitly
 }

--- a/app/pages/ukCompanies/CheckAnswersUkCompanyPage.scala
+++ b/app/pages/ukCompanies/CheckAnswersUkCompanyPage.scala
@@ -24,6 +24,4 @@ case object CheckAnswersUkCompanyPage extends QuestionPage[String] {
 
   override def toString: String = "checkAnswersUkCompany"
 
-  val reads = implicitly
-  val writes = implicitly
 }

--- a/app/pages/ukCompanies/CheckAnswersUkCompanyPage.scala
+++ b/app/pages/ukCompanies/CheckAnswersUkCompanyPage.scala
@@ -23,5 +23,4 @@ case object CheckAnswersUkCompanyPage extends QuestionPage[String] {
   override def path: JsPath = JsPath \ toString
 
   override def toString: String = "checkAnswersUkCompany"
-
 }

--- a/app/pages/ukCompanies/CompanyAccountingPeriodSameAsGroupPage.scala
+++ b/app/pages/ukCompanies/CompanyAccountingPeriodSameAsGroupPage.scala
@@ -24,6 +24,4 @@ case object CompanyAccountingPeriodSameAsGroupPage extends QuestionPage[Boolean]
 
   override def toString: String = "companyAccountingPeriodSameAsGroup"
 
-  val reads = implicitly
-  val writes = implicitly
 }

--- a/app/pages/ukCompanies/CompanyAccountingPeriodSameAsGroupPage.scala
+++ b/app/pages/ukCompanies/CompanyAccountingPeriodSameAsGroupPage.scala
@@ -23,5 +23,4 @@ case object CompanyAccountingPeriodSameAsGroupPage extends QuestionPage[Boolean]
   override def path: JsPath = JsPath \ toString
 
   override def toString: String = "companyAccountingPeriodSameAsGroup"
-
 }

--- a/app/pages/ukCompanies/CompanyAccountingPeriodSameAsGroupPage.scala
+++ b/app/pages/ukCompanies/CompanyAccountingPeriodSameAsGroupPage.scala
@@ -23,4 +23,7 @@ case object CompanyAccountingPeriodSameAsGroupPage extends QuestionPage[Boolean]
   override def path: JsPath = JsPath \ toString
 
   override def toString: String = "companyAccountingPeriodSameAsGroup"
+
+  val reads = implicitly
+  val writes = implicitly
 }

--- a/app/pages/ukCompanies/CompanyDetailsPage.scala
+++ b/app/pages/ukCompanies/CompanyDetailsPage.scala
@@ -24,4 +24,7 @@ case object CompanyDetailsPage extends QuestionPage[CompanyDetailsModel] {
   override def path: JsPath = JsPath \ toString
 
   override def toString: String = "companyDetails"
+
+  val reads = implicitly
+  val writes = implicitly
 }

--- a/app/pages/ukCompanies/CompanyDetailsPage.scala
+++ b/app/pages/ukCompanies/CompanyDetailsPage.scala
@@ -25,6 +25,4 @@ case object CompanyDetailsPage extends QuestionPage[CompanyDetailsModel] {
 
   override def toString: String = "companyDetails"
 
-  val reads = implicitly
-  val writes = implicitly
 }

--- a/app/pages/ukCompanies/CompanyDetailsPage.scala
+++ b/app/pages/ukCompanies/CompanyDetailsPage.scala
@@ -24,5 +24,4 @@ case object CompanyDetailsPage extends QuestionPage[CompanyDetailsModel] {
   override def path: JsPath = JsPath \ toString
 
   override def toString: String = "companyDetails"
-
 }

--- a/app/pages/ukCompanies/ConsentingCompanyPage.scala
+++ b/app/pages/ukCompanies/ConsentingCompanyPage.scala
@@ -24,6 +24,4 @@ case object ConsentingCompanyPage extends QuestionPage[Boolean] {
 
   override def toString: String = "consentingCompany"
 
-  val reads = implicitly
-  val writes = implicitly
 }

--- a/app/pages/ukCompanies/ConsentingCompanyPage.scala
+++ b/app/pages/ukCompanies/ConsentingCompanyPage.scala
@@ -23,5 +23,4 @@ case object ConsentingCompanyPage extends QuestionPage[Boolean] {
   override def path: JsPath = JsPath \ toString
 
   override def toString: String = "consentingCompany"
-
 }

--- a/app/pages/ukCompanies/ConsentingCompanyPage.scala
+++ b/app/pages/ukCompanies/ConsentingCompanyPage.scala
@@ -23,4 +23,7 @@ case object ConsentingCompanyPage extends QuestionPage[Boolean] {
   override def path: JsPath = JsPath \ toString
 
   override def toString: String = "consentingCompany"
+
+  val reads = implicitly
+  val writes = implicitly
 }

--- a/app/pages/ukCompanies/EnterCompanyTaxEBITDAPage.scala
+++ b/app/pages/ukCompanies/EnterCompanyTaxEBITDAPage.scala
@@ -23,5 +23,4 @@ case object EnterCompanyTaxEBITDAPage extends QuestionPage[BigDecimal] {
   override def path: JsPath = JsPath \ toString
 
   override def toString: String = "enterCompanyTaxEBITDA"
-
 }

--- a/app/pages/ukCompanies/EnterCompanyTaxEBITDAPage.scala
+++ b/app/pages/ukCompanies/EnterCompanyTaxEBITDAPage.scala
@@ -24,6 +24,4 @@ case object EnterCompanyTaxEBITDAPage extends QuestionPage[BigDecimal] {
 
   override def toString: String = "enterCompanyTaxEBITDA"
 
-  val reads = implicitly
-  val writes = implicitly
 }

--- a/app/pages/ukCompanies/EnterCompanyTaxEBITDAPage.scala
+++ b/app/pages/ukCompanies/EnterCompanyTaxEBITDAPage.scala
@@ -23,4 +23,7 @@ case object EnterCompanyTaxEBITDAPage extends QuestionPage[BigDecimal] {
   override def path: JsPath = JsPath \ toString
 
   override def toString: String = "enterCompanyTaxEBITDA"
+
+  val reads = implicitly
+  val writes = implicitly
 }

--- a/app/pages/ukCompanies/NetTaxInterestAmountPage.scala
+++ b/app/pages/ukCompanies/NetTaxInterestAmountPage.scala
@@ -24,6 +24,4 @@ case object NetTaxInterestAmountPage extends QuestionPage[BigDecimal] {
 
   override def toString: String = "netTaxInterestAmount"
 
-  val reads = implicitly
-  val writes = implicitly
 }

--- a/app/pages/ukCompanies/NetTaxInterestAmountPage.scala
+++ b/app/pages/ukCompanies/NetTaxInterestAmountPage.scala
@@ -23,5 +23,4 @@ case object NetTaxInterestAmountPage extends QuestionPage[BigDecimal] {
   override def path: JsPath = JsPath \ toString
 
   override def toString: String = "netTaxInterestAmount"
-
 }

--- a/app/pages/ukCompanies/NetTaxInterestAmountPage.scala
+++ b/app/pages/ukCompanies/NetTaxInterestAmountPage.scala
@@ -23,4 +23,7 @@ case object NetTaxInterestAmountPage extends QuestionPage[BigDecimal] {
   override def path: JsPath = JsPath \ toString
 
   override def toString: String = "netTaxInterestAmount"
+
+  val reads = implicitly
+  val writes = implicitly
 }

--- a/app/pages/ukCompanies/NetTaxInterestIncomeOrExpensePage.scala
+++ b/app/pages/ukCompanies/NetTaxInterestIncomeOrExpensePage.scala
@@ -25,6 +25,4 @@ case object NetTaxInterestIncomeOrExpensePage extends QuestionPage[NetTaxInteres
 
   override def toString: String = "netTaxInterestIncomeOrExpense"
 
-  val reads = implicitly
-  val writes = implicitly
 }

--- a/app/pages/ukCompanies/NetTaxInterestIncomeOrExpensePage.scala
+++ b/app/pages/ukCompanies/NetTaxInterestIncomeOrExpensePage.scala
@@ -24,5 +24,4 @@ case object NetTaxInterestIncomeOrExpensePage extends QuestionPage[NetTaxInteres
   override def path: JsPath = JsPath \ toString
 
   override def toString: String = "netTaxInterestIncomeOrExpense"
-
 }

--- a/app/pages/ukCompanies/NetTaxInterestIncomeOrExpensePage.scala
+++ b/app/pages/ukCompanies/NetTaxInterestIncomeOrExpensePage.scala
@@ -24,4 +24,7 @@ case object NetTaxInterestIncomeOrExpensePage extends QuestionPage[NetTaxInteres
   override def path: JsPath = JsPath \ toString
 
   override def toString: String = "netTaxInterestIncomeOrExpense"
+
+  val reads = implicitly
+  val writes = implicitly
 }

--- a/app/pages/ukCompanies/ReactivationAmountPage.scala
+++ b/app/pages/ukCompanies/ReactivationAmountPage.scala
@@ -24,6 +24,4 @@ case object ReactivationAmountPage extends QuestionPage[BigDecimal] {
 
   override def toString: String = "reactivationAmount"
 
-  val reads = implicitly
-  val writes = implicitly
 }

--- a/app/pages/ukCompanies/ReactivationAmountPage.scala
+++ b/app/pages/ukCompanies/ReactivationAmountPage.scala
@@ -23,4 +23,7 @@ case object ReactivationAmountPage extends QuestionPage[BigDecimal] {
   override def path: JsPath = JsPath \ toString
 
   override def toString: String = "reactivationAmount"
+
+  val reads = implicitly
+  val writes = implicitly
 }

--- a/app/pages/ukCompanies/ReactivationAmountPage.scala
+++ b/app/pages/ukCompanies/ReactivationAmountPage.scala
@@ -23,5 +23,4 @@ case object ReactivationAmountPage extends QuestionPage[BigDecimal] {
   override def path: JsPath = JsPath \ toString
 
   override def toString: String = "reactivationAmount"
-
 }

--- a/app/pages/ukCompanies/RestrictionAmountSameAPPage.scala
+++ b/app/pages/ukCompanies/RestrictionAmountSameAPPage.scala
@@ -23,4 +23,7 @@ case object RestrictionAmountSameAPPage extends QuestionPage[BigDecimal] {
   override def path: JsPath = JsPath \ toString
 
   override def toString: String = "restrictionAmountSameAP"
+
+  val reads = implicitly
+  val writes = implicitly
 }

--- a/app/pages/ukCompanies/RestrictionAmountSameAPPage.scala
+++ b/app/pages/ukCompanies/RestrictionAmountSameAPPage.scala
@@ -24,6 +24,4 @@ case object RestrictionAmountSameAPPage extends QuestionPage[BigDecimal] {
 
   override def toString: String = "restrictionAmountSameAP"
 
-  val reads = implicitly
-  val writes = implicitly
 }

--- a/app/pages/ukCompanies/RestrictionAmountSameAPPage.scala
+++ b/app/pages/ukCompanies/RestrictionAmountSameAPPage.scala
@@ -23,5 +23,4 @@ case object RestrictionAmountSameAPPage extends QuestionPage[BigDecimal] {
   override def path: JsPath = JsPath \ toString
 
   override def toString: String = "restrictionAmountSameAP"
-
 }

--- a/app/pages/ukCompanies/UkCompaniesDeletionConfirmationPage.scala
+++ b/app/pages/ukCompanies/UkCompaniesDeletionConfirmationPage.scala
@@ -24,5 +24,4 @@ case object UkCompaniesDeletionConfirmationPage extends QuestionPage[Boolean] {
   override def path: JsPath = JsPath \ toString
 
   override def toString: String = "ukCompaniesDeletionConfirmation"
-
 }

--- a/app/pages/ukCompanies/UkCompaniesDeletionConfirmationPage.scala
+++ b/app/pages/ukCompanies/UkCompaniesDeletionConfirmationPage.scala
@@ -25,6 +25,4 @@ case object UkCompaniesDeletionConfirmationPage extends QuestionPage[Boolean] {
 
   override def toString: String = "ukCompaniesDeletionConfirmation"
 
-  val reads = implicitly
-  val writes = implicitly
 }

--- a/app/pages/ukCompanies/UkCompaniesDeletionConfirmationPage.scala
+++ b/app/pages/ukCompanies/UkCompaniesDeletionConfirmationPage.scala
@@ -24,4 +24,7 @@ case object UkCompaniesDeletionConfirmationPage extends QuestionPage[Boolean] {
   override def path: JsPath = JsPath \ toString
 
   override def toString: String = "ukCompaniesDeletionConfirmation"
+
+  val reads = implicitly
+  val writes = implicitly
 }

--- a/app/pages/ukCompanies/UkCompaniesPage.scala
+++ b/app/pages/ukCompanies/UkCompaniesPage.scala
@@ -25,6 +25,6 @@ case object UkCompaniesPage extends QuestionPage[UkCompanyModel] {
 
   override def toString: String = "ukCompanies"
 
-  val reads = implicitly
-  val writes = implicitly
+  
+  
 }

--- a/app/pages/ukCompanies/UkCompaniesPage.scala
+++ b/app/pages/ukCompanies/UkCompaniesPage.scala
@@ -24,4 +24,7 @@ case object UkCompaniesPage extends QuestionPage[UkCompanyModel] {
   override def path: JsPath = JsPath \ toString
 
   override def toString: String = "ukCompanies"
+
+  val reads = implicitly
+  val writes = implicitly
 }

--- a/app/pages/ultimateParentCompany/CheckAnswersGroupStructurePage.scala
+++ b/app/pages/ultimateParentCompany/CheckAnswersGroupStructurePage.scala
@@ -25,6 +25,4 @@ case object CheckAnswersGroupStructurePage extends QuestionPage[String] {
 
   override def toString: String = "checkAnswersGroupStructure"
 
-  val reads = implicitly
-  val writes = implicitly
 }

--- a/app/pages/ultimateParentCompany/CheckAnswersGroupStructurePage.scala
+++ b/app/pages/ultimateParentCompany/CheckAnswersGroupStructurePage.scala
@@ -24,5 +24,4 @@ case object CheckAnswersGroupStructurePage extends QuestionPage[String] {
   override def path: JsPath = JsPath \ toString
 
   override def toString: String = "checkAnswersGroupStructure"
-
 }

--- a/app/pages/ultimateParentCompany/CountryOfIncorporationPage.scala
+++ b/app/pages/ultimateParentCompany/CountryOfIncorporationPage.scala
@@ -24,5 +24,4 @@ case object CountryOfIncorporationPage extends QuestionPage[String] {
   override def path: JsPath = JsPath \ toString
 
   override def toString: String = "countryOfIncorporation"
-
 }

--- a/app/pages/ultimateParentCompany/CountryOfIncorporationPage.scala
+++ b/app/pages/ultimateParentCompany/CountryOfIncorporationPage.scala
@@ -25,6 +25,4 @@ case object CountryOfIncorporationPage extends QuestionPage[String] {
 
   override def toString: String = "countryOfIncorporation"
 
-  val reads = implicitly
-  val writes = implicitly
 }

--- a/app/pages/ultimateParentCompany/CountryOfIncorporationPage.scala
+++ b/app/pages/ultimateParentCompany/CountryOfIncorporationPage.scala
@@ -24,4 +24,7 @@ case object CountryOfIncorporationPage extends QuestionPage[String] {
   override def path: JsPath = JsPath \ toString
 
   override def toString: String = "countryOfIncorporation"
+
+  val reads = implicitly
+  val writes = implicitly
 }

--- a/app/pages/ultimateParentCompany/DeemedParentPage.scala
+++ b/app/pages/ultimateParentCompany/DeemedParentPage.scala
@@ -26,6 +26,4 @@ case object DeemedParentPage extends QuestionPage[DeemedParentModel] {
 
   override def toString: String = "deemedParent"
 
-  val reads = implicitly
-  val writes = implicitly
 }

--- a/app/pages/ultimateParentCompany/DeemedParentPage.scala
+++ b/app/pages/ultimateParentCompany/DeemedParentPage.scala
@@ -25,4 +25,7 @@ case object DeemedParentPage extends QuestionPage[DeemedParentModel] {
   override def path: JsPath = JsPath \ toString
 
   override def toString: String = "deemedParent"
+
+  val reads = implicitly
+  val writes = implicitly
 }

--- a/app/pages/ultimateParentCompany/DeemedParentPage.scala
+++ b/app/pages/ultimateParentCompany/DeemedParentPage.scala
@@ -25,5 +25,4 @@ case object DeemedParentPage extends QuestionPage[DeemedParentModel] {
   override def path: JsPath = JsPath \ toString
 
   override def toString: String = "deemedParent"
-
 }

--- a/app/pages/ultimateParentCompany/DeletionConfirmationPage.scala
+++ b/app/pages/ultimateParentCompany/DeletionConfirmationPage.scala
@@ -23,5 +23,4 @@ case object DeletionConfirmationPage extends QuestionPage[Boolean] {
   override def path: JsPath = JsPath \ toString
 
   override def toString: String = "deletionConfirmation"
-
 }

--- a/app/pages/ultimateParentCompany/DeletionConfirmationPage.scala
+++ b/app/pages/ultimateParentCompany/DeletionConfirmationPage.scala
@@ -23,4 +23,7 @@ case object DeletionConfirmationPage extends QuestionPage[Boolean] {
   override def path: JsPath = JsPath \ toString
 
   override def toString: String = "deletionConfirmation"
+
+  val reads = implicitly
+  val writes = implicitly
 }

--- a/app/pages/ultimateParentCompany/DeletionConfirmationPage.scala
+++ b/app/pages/ultimateParentCompany/DeletionConfirmationPage.scala
@@ -24,6 +24,4 @@ case object DeletionConfirmationPage extends QuestionPage[Boolean] {
 
   override def toString: String = "deletionConfirmation"
 
-  val reads = implicitly
-  val writes = implicitly
 }

--- a/app/pages/ultimateParentCompany/HasDeemedParentPage.scala
+++ b/app/pages/ultimateParentCompany/HasDeemedParentPage.scala
@@ -25,6 +25,4 @@ case object HasDeemedParentPage extends QuestionPage[Boolean] {
 
   override def toString: String = "hasDeemedParent"
 
-  val reads = implicitly
-  val writes = implicitly
 }

--- a/app/pages/ultimateParentCompany/HasDeemedParentPage.scala
+++ b/app/pages/ultimateParentCompany/HasDeemedParentPage.scala
@@ -24,4 +24,7 @@ case object HasDeemedParentPage extends QuestionPage[Boolean] {
   override def path: JsPath = JsPath \ toString
 
   override def toString: String = "hasDeemedParent"
+
+  val reads = implicitly
+  val writes = implicitly
 }

--- a/app/pages/ultimateParentCompany/HasDeemedParentPage.scala
+++ b/app/pages/ultimateParentCompany/HasDeemedParentPage.scala
@@ -24,5 +24,4 @@ case object HasDeemedParentPage extends QuestionPage[Boolean] {
   override def path: JsPath = JsPath \ toString
 
   override def toString: String = "hasDeemedParent"
-
 }

--- a/app/pages/ultimateParentCompany/LimitedLiabilityPartnershipPage.scala
+++ b/app/pages/ultimateParentCompany/LimitedLiabilityPartnershipPage.scala
@@ -25,6 +25,4 @@ case object LimitedLiabilityPartnershipPage extends QuestionPage[Boolean] {
 
   override def toString: String = "limitedLiabilityPartnership"
 
-  val reads = implicitly
-  val writes = implicitly
 }

--- a/app/pages/ultimateParentCompany/LimitedLiabilityPartnershipPage.scala
+++ b/app/pages/ultimateParentCompany/LimitedLiabilityPartnershipPage.scala
@@ -24,5 +24,4 @@ case object LimitedLiabilityPartnershipPage extends QuestionPage[Boolean] {
   override def path: JsPath = JsPath \ toString
 
   override def toString: String = "limitedLiabilityPartnership"
-
 }

--- a/app/pages/ultimateParentCompany/LimitedLiabilityPartnershipPage.scala
+++ b/app/pages/ultimateParentCompany/LimitedLiabilityPartnershipPage.scala
@@ -24,4 +24,7 @@ case object LimitedLiabilityPartnershipPage extends QuestionPage[Boolean] {
   override def path: JsPath = JsPath \ toString
 
   override def toString: String = "limitedLiabilityPartnership"
+
+  val reads = implicitly
+  val writes = implicitly
 }

--- a/app/pages/ultimateParentCompany/ParentCompanyCTUTRPage.scala
+++ b/app/pages/ultimateParentCompany/ParentCompanyCTUTRPage.scala
@@ -24,5 +24,4 @@ case object ParentCompanyCTUTRPage extends QuestionPage[String] {
   override def path: JsPath = JsPath \ toString
 
   override def toString: String = "parentCompanyCTUTR"
-
 }

--- a/app/pages/ultimateParentCompany/ParentCompanyCTUTRPage.scala
+++ b/app/pages/ultimateParentCompany/ParentCompanyCTUTRPage.scala
@@ -25,6 +25,4 @@ case object ParentCompanyCTUTRPage extends QuestionPage[String] {
 
   override def toString: String = "parentCompanyCTUTR"
 
-  val reads = implicitly
-  val writes = implicitly
 }

--- a/app/pages/ultimateParentCompany/ParentCompanyCTUTRPage.scala
+++ b/app/pages/ultimateParentCompany/ParentCompanyCTUTRPage.scala
@@ -24,4 +24,7 @@ case object ParentCompanyCTUTRPage extends QuestionPage[String] {
   override def path: JsPath = JsPath \ toString
 
   override def toString: String = "parentCompanyCTUTR"
+
+  val reads = implicitly
+  val writes = implicitly
 }

--- a/app/pages/ultimateParentCompany/ParentCompanyNamePage.scala
+++ b/app/pages/ultimateParentCompany/ParentCompanyNamePage.scala
@@ -24,4 +24,7 @@ case object ParentCompanyNamePage extends QuestionPage[String] {
   override def path: JsPath = JsPath \ toString
 
   override def toString: String = "parentCompanyName"
+
+  val reads = implicitly
+  val writes = implicitly
 }

--- a/app/pages/ultimateParentCompany/ParentCompanyNamePage.scala
+++ b/app/pages/ultimateParentCompany/ParentCompanyNamePage.scala
@@ -24,5 +24,4 @@ case object ParentCompanyNamePage extends QuestionPage[String] {
   override def path: JsPath = JsPath \ toString
 
   override def toString: String = "parentCompanyName"
-
 }

--- a/app/pages/ultimateParentCompany/ParentCompanyNamePage.scala
+++ b/app/pages/ultimateParentCompany/ParentCompanyNamePage.scala
@@ -25,6 +25,4 @@ case object ParentCompanyNamePage extends QuestionPage[String] {
 
   override def toString: String = "parentCompanyName"
 
-  val reads = implicitly
-  val writes = implicitly
 }

--- a/app/pages/ultimateParentCompany/ParentCompanySAUTRPage.scala
+++ b/app/pages/ultimateParentCompany/ParentCompanySAUTRPage.scala
@@ -24,5 +24,4 @@ case object ParentCompanySAUTRPage extends QuestionPage[String] {
   override def path: JsPath = JsPath \ toString
 
   override def toString: String = "parentCompanySAUTR"
-
 }

--- a/app/pages/ultimateParentCompany/ParentCompanySAUTRPage.scala
+++ b/app/pages/ultimateParentCompany/ParentCompanySAUTRPage.scala
@@ -24,4 +24,7 @@ case object ParentCompanySAUTRPage extends QuestionPage[String] {
   override def path: JsPath = JsPath \ toString
 
   override def toString: String = "parentCompanySAUTR"
+
+  val reads = implicitly
+  val writes = implicitly
 }

--- a/app/pages/ultimateParentCompany/ParentCompanySAUTRPage.scala
+++ b/app/pages/ultimateParentCompany/ParentCompanySAUTRPage.scala
@@ -25,6 +25,4 @@ case object ParentCompanySAUTRPage extends QuestionPage[String] {
 
   override def toString: String = "parentCompanySAUTR"
 
-  val reads = implicitly
-  val writes = implicitly
 }

--- a/app/pages/ultimateParentCompany/PayTaxInUkPage.scala
+++ b/app/pages/ultimateParentCompany/PayTaxInUkPage.scala
@@ -25,6 +25,6 @@ case object PayTaxInUkPage extends QuestionPage[Boolean] {
 
   override def toString: String = "payTaxInUk"
 
-    val reads = implicitly
-  val writes = implicitly
+    
+  
 }

--- a/app/pages/ultimateParentCompany/PayTaxInUkPage.scala
+++ b/app/pages/ultimateParentCompany/PayTaxInUkPage.scala
@@ -24,4 +24,7 @@ case object PayTaxInUkPage extends QuestionPage[Boolean] {
   override def path: JsPath = JsPath \ toString
 
   override def toString: String = "payTaxInUk"
+
+    val reads = implicitly
+  val writes = implicitly
 }

--- a/app/pages/ultimateParentCompany/ReportingCompanySameAsParentPage.scala
+++ b/app/pages/ultimateParentCompany/ReportingCompanySameAsParentPage.scala
@@ -38,4 +38,8 @@ case object ReportingCompanySameAsParentPage extends QuestionPage[Boolean] {
       }
     }
   }
+
+  val reads = implicitly
+  val writes = implicitly
+
 }

--- a/app/pages/ultimateParentCompany/ReportingCompanySameAsParentPage.scala
+++ b/app/pages/ultimateParentCompany/ReportingCompanySameAsParentPage.scala
@@ -39,7 +39,7 @@ case object ReportingCompanySameAsParentPage extends QuestionPage[Boolean] {
     }
   }
 
-  val reads = implicitly
-  val writes = implicitly
+  
+  
 
 }

--- a/app/sectionstatus/AboutReturnSectionStatus.scala
+++ b/app/sectionstatus/AboutReturnSectionStatus.scala
@@ -16,43 +16,59 @@
 
 package sectionstatus
 
-import models.SectionStatus._
-import models.{SectionStatus, UserAnswers}
+import models.sections.AboutReturnSectionModel
+import models._
+import models.returnModels._
 import pages.aboutReturn._
 import pages.groupLevelInformation.RevisingReturnPage
+import pages.Page._
 
-object AboutReturnSectionStatus {
+object AboutReturnSectionStatus extends CurrentSectionStatus[AboutReturnSectionModel] {
+
+  val pages = aboutReturnSectionPages
+
+  def isComplete(section: AboutReturnSectionModel) = 
+    agentDetailsComplete(section.agentDetails) && revisedReturnDetailsComplete(section.isRevisingReturn, section.revisedReturnDetails)
   
-  def getStatus(userAnswers: UserAnswers): SectionStatus = {
-
-    val requiredPages = List(
-      userAnswers.get(ReportingCompanyAppointedPage),
-      userAnswers.get(AgentActingOnBehalfOfCompanyPage),
-      userAnswers.get(FullOrAbbreviatedReturnPage),
-      userAnswers.get(RevisingReturnPage),
-      userAnswers.get(ReportingCompanyNamePage),
-      userAnswers.get(ReportingCompanyCTUTRPage),
-      userAnswers.get(AccountingPeriodPage)
-    )
-    
-    val optionalAgentPages =
-      userAnswers.get(AgentActingOnBehalfOfCompanyPage) match {
-        case Some(true) => Seq(userAnswers.get(AgentNamePage))
-        case _ => Nil
-      }
-
-    val optionalRevisionPages =
-      userAnswers.get(RevisingReturnPage) match {
-        case Some(true) => Seq(userAnswers.get(TellUsWhatHasChangedPage))
-        case _ => Nil
-      }
-
-    val pages = requiredPages ++ optionalAgentPages ++ optionalRevisionPages
-
-    pages.flatten match {
-      case result if result.isEmpty => NotStarted
-      case result if result.size == pages.size => Completed
-      case _ => InProgress
+  def agentDetailsComplete(agentDetails: AgentDetailsModel): Boolean = 
+    agentDetails match {
+      case AgentDetailsModel(true, Some(_)) => true
+      case AgentDetailsModel(false, _) => true
+      case _ => false
     }
-  }
+
+  def revisedReturnDetailsComplete(isRevisingReturn: Boolean, revisedReturnDetails: Option[String]): Boolean = 
+    (isRevisingReturn, revisedReturnDetails) match {
+      case (true, Some(_)) => true
+      case (false, _) => true
+      case (_, _) => false
+    }
+  
+  def currentSection(userAnswers: UserAnswers): Option[AboutReturnSectionModel] = 
+    for {
+      appointedReportingCompany     <- userAnswers.get(ReportingCompanyAppointedPage)
+      agentActingOnBehalfOfCompany  <- userAnswers.get(AgentActingOnBehalfOfCompanyPage)
+      fullOrAbbreviatedReturn       <- userAnswers.get(FullOrAbbreviatedReturnPage)
+      isRevisingReturn              <- userAnswers.get(RevisingReturnPage)
+      companyName                   <- userAnswers.get(ReportingCompanyNamePage)
+      ctutr                         <- userAnswers.get(ReportingCompanyCTUTRPage)
+      periodOfAccount               <- userAnswers.get(AccountingPeriodPage)
+    } yield {
+
+      val agentDetailsModel = AgentDetailsModel(
+        agentActingOnBehalfOfCompany  = agentActingOnBehalfOfCompany,
+        agentName                     = userAnswers.get(AgentNamePage)
+      )
+
+      AboutReturnSectionModel(
+        appointedReportingCompany     = appointedReportingCompany,
+        agentDetails                  = agentDetailsModel,
+        fullOrAbbreviatedReturn       = fullOrAbbreviatedReturn,
+        isRevisingReturn              = isRevisingReturn,
+        revisedReturnDetails          = userAnswers.get(TellUsWhatHasChangedPage),
+        companyName                   = CompanyNameModel(companyName),
+        ctutr                         = UTRModel(ctutr),
+        periodOfAccount               = periodOfAccount
+      )
+    }
 }

--- a/app/sectionstatus/AboutReturnSectionStatus.scala
+++ b/app/sectionstatus/AboutReturnSectionStatus.scala
@@ -23,7 +23,7 @@ import pages.groupLevelInformation.RevisingReturnPage
 
 object AboutReturnSectionStatus {
   
-  def aboutReturnSectionStatus(userAnswers: UserAnswers): SectionStatus = {
+  def getStatus(userAnswers: UserAnswers): SectionStatus = {
 
     val requiredPages = List(
       userAnswers.get(ReportingCompanyAppointedPage),

--- a/app/sectionstatus/CurrentSectionStatus.scala
+++ b/app/sectionstatus/CurrentSectionStatus.scala
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2021 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package sectionstatus
+
+import pages.{Page, QuestionPage}
+import models.{UserAnswers, SectionStatus}
+import models.SectionStatus._
+
+trait CurrentSectionStatus[A] {
+
+  def pages: Seq[Page]
+
+  def currentSection(userAnswers: UserAnswers): Option[A]
+
+  def isComplete(section: A): Boolean
+
+  def sectionQuestionPages = pages.collect{case page: QuestionPage[_] => page}
+  def isNotStarted(userAnswers: UserAnswers) = sectionQuestionPages.map(userAnswers.get(_)).flatten.isEmpty
+  
+  def getStatus(userAnswers: UserAnswers): SectionStatus = 
+    (isNotStarted(userAnswers), currentSection(userAnswers)) match {
+      case (true, _)                                  => NotStarted
+      case (_, Some(section)) if isComplete(section)  => Completed
+      case (_, _)                                     => InProgress
+    }
+}

--- a/app/sectionstatus/ElectionsSectionStatus.scala
+++ b/app/sectionstatus/ElectionsSectionStatus.scala
@@ -1,0 +1,121 @@
+/*
+ * Copyright 2021 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package sectionstatus
+
+import models.UserAnswers
+import pages.elections._
+import models.returnModels._
+import models.IsUKPartnershipOrPreferNotToAnswer._
+import pages.Page._
+import models.sections.ElectionsSectionModel
+
+object ElectionsSectionStatus extends CurrentSectionStatus[ElectionsSectionModel] {
+
+  val pages = electionsSectionPages
+  
+  def currentSection(userAnswers: UserAnswers): Option[ElectionsSectionModel] = {
+    
+    for {
+      groupRatioIsElected                     <- userAnswers.get(GroupRatioElectionPage)
+      interestAllowanceAlternativeCalcActive  <- userAnswers.get(ElectedInterestAllowanceAlternativeCalcBeforePage)
+      nonConsolidatedInvestmentsIsElected     <- userAnswers.get(InterestAllowanceNonConsolidatedInvestmentsElectionPage)
+      consolidatedPartnershipsActive          <- userAnswers.get(ElectedInterestAllowanceConsolidatedPshipBeforePage)
+    } yield {
+
+      val groupRatioBlended = userAnswers.get(GroupRatioBlendedElectionPage).map { isElected =>
+        val investorGroups = userAnswers.getList(InvestorGroupsPage)
+        GroupRatioBlendedModel(isElected = isElected, investorGroups = Some(investorGroups))
+      }
+
+      val consolidatedPartnerships = userAnswers.get(InterestAllowanceConsolidatedPshipElectionPage).map { isElected =>
+        val partnerships = userAnswers.getList(PartnershipsPage)
+        ConsolidatedPartnershipModel(isElected = isElected, consolidatedPartnerships = Some(partnerships))
+      }
+
+      ElectionsSectionModel(
+        groupRatioIsElected = groupRatioIsElected,
+        groupRatioBlended = groupRatioBlended,
+        groupEBITDAChargeableGainsActive = userAnswers.get(ElectedGroupEBITDABeforePage),
+        groupEBITDAChargeableGainsIsElected = userAnswers.get(GroupEBITDAChargeableGainsElectionPage),
+        interestAllowanceAlternativeCalcActive = interestAllowanceAlternativeCalcActive,
+        interestAllowanceAlternativeCalcIsElected = userAnswers.get(InterestAllowanceAlternativeCalcElectionPage),
+        nonConsolidatedInvestmentsIsElected = nonConsolidatedInvestmentsIsElected,
+        nonConsolidatedInvestmentNames = nonConsolidatedInvestmentsIsElected match {
+          case true => Some(userAnswers.getList(InvestmentNamePage))
+          case false => None
+        },
+        consolidatedPartnershipsActive = consolidatedPartnershipsActive, 
+        consolidatedPartnerships = consolidatedPartnerships
+      )
+    }
+  }
+
+  def isComplete(section: ElectionsSectionModel): Boolean = {
+    isGroupRatioPathComplete(section) && 
+    isAlternativeCalculationPathComplete(section) && 
+    nonConsolidatedInvestmentsComplete(section) && 
+    isPartnershipElectionComplete(section.consolidatedPartnerships)
+  }
+
+  def isGroupRatioPathComplete(section: ElectionsSectionModel): Boolean = section match {
+    case ElectionsSectionModel(groupRatio @ false, _, _, _, _, _, _, _, _, _) => true
+    case ElectionsSectionModel(groupRatio @ true, Some(GroupRatioBlendedModel(false, _)), ebitdaActive @ Some(true), _, _, _, _, _, _, _) => true
+    case ElectionsSectionModel(groupRatio @ true, Some(GroupRatioBlendedModel(false, _)), ebitdaActive @ Some(false), ebitdaElected @ Some(_), _, _, _, _, _, _) => true
+    case ElectionsSectionModel(groupRatio @ true, Some(GroupRatioBlendedModel(true, investorGroups)), ebitdaActive @ Some(true), _, _, _, _, _, _, _) => 
+      investorGroups.map(_.forall(isInvestorGroupComplete)).getOrElse(true)
+    case ElectionsSectionModel(groupRatio @ true, Some(GroupRatioBlendedModel(true, investorGroups)), ebitdaActive @ Some(false), ebitdaElected @ Some(_), _, _, _, _, _, _) => 
+      investorGroups.map(_.forall(isInvestorGroupComplete)).getOrElse(true)
+    case _ => false
+  }
+
+  def isAlternativeCalculationPathComplete(section: ElectionsSectionModel): Boolean = section match {
+    case ElectionsSectionModel(_, _, _, _, alternativeCalcActive @ true, _, _, _, _, _) => true
+    case ElectionsSectionModel(_, _, _, _, alternativeCalcActive @ false, alternativeCalcIsElected @ Some(_), _, _, _, _) => true
+    case _ => false
+  }
+
+  def nonConsolidatedInvestmentsComplete(section: ElectionsSectionModel): Boolean = section match {
+    case ElectionsSectionModel(_, _, _, _, _, _, nonConsolidatedInvestmentIsElected @ false, _, _, _) => true
+    case ElectionsSectionModel(_, _, _, _, _, _, nonConsolidatedInvestmentIsElected @ true, Some(Nil), _, _) => false
+    case ElectionsSectionModel(_, _, _, _, _, _, nonConsolidatedInvestmentIsElected @ true, Some(investments), _, _) => true
+    case _ => false
+  }
+
+  def isPartnershipElectionComplete(consolidatedPartnershipModel: Option[ConsolidatedPartnershipModel]): Boolean = consolidatedPartnershipModel match {
+    case Some(ConsolidatedPartnershipModel(isElected @ false, _)) => true
+    case Some(ConsolidatedPartnershipModel(isElected @ true, Some(Nil))) => false
+    case Some(ConsolidatedPartnershipModel(isElected @ true, Some(partnerships))) => 
+      partnerships.forall(isPartnershipComplete)
+    case _ => false
+  }
+
+
+  def isInvestorGroupComplete(investorGroup: InvestorGroupModel): Boolean =
+    investorGroup match {
+      case InvestorGroupModel(name, method @ Some(_), otherElections @ _) => true
+      case _ => false
+    }
+
+  def isPartnershipComplete(partnership: PartnershipModel): Boolean =
+    partnership match {
+      case PartnershipModel(name, isUkPartnership @ Some(PreferNotToAnswer), sautr) => true
+      case PartnershipModel(name, isUkPartnership @ Some(IsUkPartnership), sautr @ Some(_)) => true
+      case PartnershipModel(name, isUkPartnership @ Some(IsNotUkPartnership), sautr @ _) => true
+      case _ => false
+    }
+
+}

--- a/app/sectionstatus/UltimateParentCompanySectionStatus.scala
+++ b/app/sectionstatus/UltimateParentCompanySectionStatus.scala
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2021 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package sectionstatus
+
+import models.SectionStatus._
+import models.{SectionStatus, UserAnswers}
+import pages.ultimateParentCompany._
+import models.returnModels.DeemedParentModel
+
+object UltimateParentCompanySectionStatus {
+  
+  def getStatus(userAnswers: UserAnswers): SectionStatus = {
+
+    val initialPage = userAnswers.get(ReportingCompanySameAsParentPage)
+
+    val pages = Seq(initialPage) ++ (initialPage match {
+      case Some(false) => userAnswers.get(HasDeemedParentPage) match {
+        case Some(false) => Seq(companySectionCompleted(userAnswers, 1))
+        case Some(true) => Seq(companySectionCompleted(userAnswers, 1), companySectionCompleted(userAnswers, 2)) ++ companySectionCompletedIfStarted(userAnswers, 3)
+        case None => Seq(None)
+      }
+      case _ => Nil
+    })
+
+    pages.flatten match {
+      case result if result.isEmpty => NotStarted
+      case result if result.size == pages.size => Completed
+      case _ => InProgress
+    }
+  }
+
+  def companySectionCompletedIfStarted(userAnswers: UserAnswers, idx: Int): Seq[Option[Any]] = 
+    userAnswers.get(DeemedParentPage, Some(idx)) match {
+      case Some(_) => Seq(companySectionCompleted(userAnswers, idx))
+      case None => Nil
+    }
+  
+  def companySectionCompleted(userAnswers: UserAnswers, idx: Int): Option[Any] = 
+    userAnswers.get(DeemedParentPage, Some(idx)) match {
+      case result @ Some(DeemedParentModel(_, ctutr @ Some(_), sautr @ _, country @ _, llp @ Some(false), taxInUk @ Some(true), _)) => result
+      case result @ Some(DeemedParentModel(_, ctutr @ _, sautr @ Some(_), country @ _, llp @ Some(true), taxInUk @ Some(true), _)) => result
+      case result @ Some(DeemedParentModel(_, ctutr @ _, sautr @ _, country @ Some(_), llp @ _, taxInUk @ Some(false), _)) => result
+      case _ => None
+    }
+
+}

--- a/it/sectionstatus/ElectionsSectionStatusISpec.scala
+++ b/it/sectionstatus/ElectionsSectionStatusISpec.scala
@@ -1,0 +1,323 @@
+/*
+ * Copyright 2021 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package sectionstatus
+
+import models.SectionStatus._
+import assets.BaseITConstants
+import utils.{CreateRequestHelper, CustomMatchers, IntegrationSpecBase}
+import stubs.AuthStub
+import play.api.libs.json._
+import scala.concurrent.duration._
+import scala.concurrent.Await
+import models.OtherInvestorGroupElections.GroupEBITDA
+
+class ElectionsSectionStatusISpec extends IntegrationSpecBase with CreateRequestHelper with CustomMatchers with BaseITConstants {
+
+  implicit val ec: scala.concurrent.ExecutionContext = scala.concurrent.ExecutionContext.global
+
+  "ElectionsSectionStatus" should {
+
+    "return InProgress" when {
+
+      "UK Consolidated partnership is missing SAUTR" in {
+        AuthStub.authorised()
+
+        setAnswers(emptyUserAnswers)
+
+        val resultUserAnswers = for {
+          _ <- postRequest("/elections/group-ratio-election", Json.obj("value" -> false))()
+          _ <- postRequest("/elections/elected-interest-allowance-alternative-calc-before", Json.obj("value" -> true))()
+          _ <- postRequest("/elections/interest-allowance-non-consolidated-investments-election", Json.obj("value" -> false))()
+          _ <- postRequest("/elections/elected-interest-allowance-consolidated-pship-before", Json.obj("value" -> false))()
+          _ <- postRequest("/elections/interest-allowance-consolidated-pship-election", Json.obj("value" -> true))()
+          _ <- postRequest("/elections/partnership/1/name", Json.obj("value" -> "Name"))()
+          _ <- postRequest("/elections/partnership/1/is-uk", Json.obj("value" -> true))()
+          userAnswers <- getAnswersFuture("id")
+        } yield userAnswers
+
+        val userAnswers = Await.result(resultUserAnswers, 2.seconds).get
+        ElectionsSectionStatus.getStatus(userAnswers) shouldEqual InProgress
+      }
+
+      "No active alternative calculation but hasn't answered Alternative Calc Elect" in {
+        AuthStub.authorised()
+
+        setAnswers(emptyUserAnswers)
+
+        val resultUserAnswers = for {
+          _ <- postRequest("/elections/group-ratio-election", Json.obj("value" -> false))()
+          _ <- postRequest("/elections/elected-interest-allowance-alternative-calc-before", Json.obj("value" -> false))()
+          _ <- postRequest("/elections/interest-allowance-non-consolidated-investments-election", Json.obj("value" -> false))()
+          _ <- postRequest("/elections/elected-interest-allowance-consolidated-pship-before", Json.obj("value" -> false))()
+          _ <- postRequest("/elections/interest-allowance-consolidated-pship-election", Json.obj("value" -> false))()
+          userAnswers <- getAnswersFuture("id")
+        } yield userAnswers
+
+        val userAnswers = Await.result(resultUserAnswers, 2.seconds).get
+        ElectionsSectionStatus.getStatus(userAnswers) shouldEqual InProgress
+      }
+
+      "Answered true for non consolidated investments but none added" in {
+        AuthStub.authorised()
+
+        setAnswers(emptyUserAnswers)
+
+        val resultUserAnswers = for {
+          _ <- postRequest("/elections/group-ratio-election", Json.obj("value" -> false))()
+          _ <- postRequest("/elections/elected-interest-allowance-alternative-calc-before", Json.obj("value" -> true))()
+          _ <- postRequest("/elections/interest-allowance-non-consolidated-investments-election", Json.obj("value" -> true))()
+          _ <- postRequest("/elections/elected-interest-allowance-consolidated-pship-before", Json.obj("value" -> false))()
+          _ <- postRequest("/elections/interest-allowance-consolidated-pship-election", Json.obj("value" -> false))()
+          userAnswers <- getAnswersFuture("id")
+        } yield userAnswers
+
+        val userAnswers = Await.result(resultUserAnswers, 2.seconds).get
+        ElectionsSectionStatus.getStatus(userAnswers) shouldEqual InProgress
+      }
+
+      "Answered true for consolidated partnerships but none added" in {
+        AuthStub.authorised()
+
+        setAnswers(emptyUserAnswers)
+
+        val resultUserAnswers = for {
+          _ <- postRequest("/elections/group-ratio-election", Json.obj("value" -> false))()
+          _ <- postRequest("/elections/elected-interest-allowance-alternative-calc-before", Json.obj("value" -> true))()
+          _ <- postRequest("/elections/interest-allowance-non-consolidated-investments-election", Json.obj("value" -> false))()
+          _ <- postRequest("/elections/elected-interest-allowance-consolidated-pship-before", Json.obj("value" -> false))()
+          _ <- postRequest("/elections/interest-allowance-consolidated-pship-election", Json.obj("value" -> true))()
+          userAnswers <- getAnswersFuture("id")
+        } yield userAnswers
+
+        val userAnswers = Await.result(resultUserAnswers, 2.seconds).get
+        ElectionsSectionStatus.getStatus(userAnswers) shouldEqual InProgress
+      }
+
+      "Answered true for group ratio and false for active EBIDTA but EBIDTA elect not completed" in {
+        AuthStub.authorised()
+
+        setAnswers(emptyUserAnswers)
+
+        val resultUserAnswers = for {
+          _ <- postRequest("/elections/group-ratio-election", Json.obj("value" -> true))()
+          _ <- postRequest("/elections/group-ratio-blended-election", Json.obj("value" -> false))()
+          _ <- postRequest("/elections/elected-group-ebitda-before", Json.obj("value" -> false))()
+          _ <- postRequest("/elections/elected-interest-allowance-alternative-calc-before", Json.obj("value" -> false))()
+          _ <- postRequest("/elections/interest-allowance-alternative-calc-election", Json.obj("value" -> false))()
+          _ <- postRequest("/elections/interest-allowance-non-consolidated-investments-election", Json.obj("value" -> false))()
+          _ <- postRequest("/elections/elected-interest-allowance-consolidated-pship-before", Json.obj("value" -> false))()
+          _ <- postRequest("/elections/interest-allowance-consolidated-pship-election", Json.obj("value" -> false))()
+          userAnswers <- getAnswersFuture("id")
+        } yield userAnswers
+
+        val userAnswers = Await.result(resultUserAnswers, 2.seconds).get
+        ElectionsSectionStatus.getStatus(userAnswers) shouldEqual InProgress
+      }
+
+    }
+    
+    "return Completed" when {
+      "Not group ratio / Active interest allowance (alt) / No non-con investments / No consolidated partnerships" in {
+        AuthStub.authorised()
+
+        setAnswers(emptyUserAnswers)
+
+        val resultUserAnswers = for {
+          _ <- postRequest("/elections/group-ratio-election", Json.obj("value" -> false))()
+          _ <- postRequest("/elections/elected-interest-allowance-alternative-calc-before", Json.obj("value" -> true))()
+          _ <- postRequest("/elections/interest-allowance-non-consolidated-investments-election", Json.obj("value" -> false))()
+          _ <- postRequest("/elections/elected-interest-allowance-consolidated-pship-before", Json.obj("value" -> false))()
+          _ <- postRequest("/elections/interest-allowance-consolidated-pship-election", Json.obj("value" -> false))()
+          userAnswers <- getAnswersFuture("id")
+        } yield userAnswers
+
+        val userAnswers = Await.result(resultUserAnswers, 2.seconds).get
+        ElectionsSectionStatus.getStatus(userAnswers) shouldEqual Completed
+      }
+
+      "Group ratio / Not blended / Active EBITDA / Active interest allowance (alt) / Not interest allowance non-con / Consolidated partnerships" in {
+        AuthStub.authorised()
+
+        setAnswers(emptyUserAnswers)
+
+        val resultUserAnswers = for {
+          _ <- postRequest("/elections/group-ratio-election", Json.obj("value" -> true))()
+          _ <- postRequest("/elections/group-ratio-blended-election", Json.obj("value" -> false))()
+          _ <- postRequest("/elections/elected-group-ebitda-before", Json.obj("value" -> true))()
+          _ <- postRequest("/elections/elected-interest-allowance-alternative-calc-before", Json.obj("value" -> true))()
+          _ <- postRequest("/elections/interest-allowance-non-consolidated-investments-election", Json.obj("value" -> false))()
+          _ <- postRequest("/elections/elected-interest-allowance-consolidated-pship-before", Json.obj("value" -> false))()
+          _ <- postRequest("/elections/interest-allowance-consolidated-pship-election", Json.obj("value" -> false))()
+          userAnswers <- getAnswersFuture("id")
+        } yield userAnswers
+
+        val userAnswers = Await.result(resultUserAnswers, 2.seconds).get
+        ElectionsSectionStatus.getStatus(userAnswers) shouldEqual Completed
+      }
+
+      "Group ratio / Not blended / No active EBITDA / Active interest allowance (alt) / Not interest allowance non-con / Consolidated partnerships" in {
+        AuthStub.authorised()
+
+        setAnswers(emptyUserAnswers)
+
+        val resultUserAnswers = for {
+          _ <- postRequest("/elections/group-ratio-election", Json.obj("value" -> true))()
+          _ <- postRequest("/elections/group-ratio-blended-election", Json.obj("value" -> false))()
+          _ <- postRequest("/elections/elected-group-ebitda-before", Json.obj("value" -> false))()
+          _ <- postRequest("/elections/group-ebitda-chargeable-gains-election", Json.obj("value" -> true))()
+          _ <- postRequest("/elections/elected-interest-allowance-alternative-calc-before", Json.obj("value" -> true))()
+          _ <- postRequest("/elections/interest-allowance-non-consolidated-investments-election", Json.obj("value" -> false))()
+          _ <- postRequest("/elections/elected-interest-allowance-consolidated-pship-before", Json.obj("value" -> false))()
+          _ <- postRequest("/elections/interest-allowance-consolidated-pship-election", Json.obj("value" -> false))()
+          userAnswers <- getAnswersFuture("id")
+        } yield userAnswers
+
+        val userAnswers = Await.result(resultUserAnswers, 2.seconds).get
+        ElectionsSectionStatus.getStatus(userAnswers) shouldEqual Completed
+      }
+
+      "Group ratio / Not blended / No active EBITDA / No active interest allowance (alt) / Not interest allowance non-con / Consolidated partnerships" in {
+        AuthStub.authorised()
+
+        setAnswers(emptyUserAnswers)
+
+        val resultUserAnswers = for {
+          _ <- postRequest("/elections/group-ratio-election", Json.obj("value" -> true))()
+          _ <- postRequest("/elections/group-ratio-blended-election", Json.obj("value" -> false))()
+          _ <- postRequest("/elections/elected-group-ebitda-before", Json.obj("value" -> false))()
+          _ <- postRequest("/elections/group-ebitda-chargeable-gains-election", Json.obj("value" -> true))()
+          _ <- postRequest("/elections/elected-interest-allowance-alternative-calc-before", Json.obj("value" -> false))()
+          _ <- postRequest("/elections/interest-allowance-alternative-calc-election", Json.obj("value" -> false))()
+          _ <- postRequest("/elections/interest-allowance-non-consolidated-investments-election", Json.obj("value" -> false))()
+          _ <- postRequest("/elections/elected-interest-allowance-consolidated-pship-before", Json.obj("value" -> false))()
+          _ <- postRequest("/elections/interest-allowance-consolidated-pship-election", Json.obj("value" -> false))()
+          userAnswers <- getAnswersFuture("id")
+        } yield userAnswers
+
+        val userAnswers = Await.result(resultUserAnswers, 2.seconds).get
+        ElectionsSectionStatus.getStatus(userAnswers) shouldEqual Completed
+      }
+
+      "Group ratio / Blended / No active EBITDA / No active interest allowance (alt) / Not interest allowance non-con / Consolidated partnerships" in {
+        AuthStub.authorised()
+
+        setAnswers(emptyUserAnswers)
+
+        val resultUserAnswers = for {
+          _ <- postRequest("/elections/group-ratio-election", Json.obj("value" -> true))()
+          _ <- postRequest("/elections/group-ratio-blended-election", Json.obj("value" -> true))()
+          _ <- postRequest("/elections/elected-group-ebitda-before", Json.obj("value" -> false))()
+          _ <- postRequest("/elections/group-ebitda-chargeable-gains-election", Json.obj("value" -> true))()
+          _ <- postRequest("/elections/elected-interest-allowance-alternative-calc-before", Json.obj("value" -> false))()
+          _ <- postRequest("/elections/interest-allowance-alternative-calc-election", Json.obj("value" -> false))()
+          _ <- postRequest("/elections/interest-allowance-non-consolidated-investments-election", Json.obj("value" -> false))()
+          _ <- postRequest("/elections/elected-interest-allowance-consolidated-pship-before", Json.obj("value" -> false))()
+          _ <- postRequest("/elections/interest-allowance-consolidated-pship-election", Json.obj("value" -> false))()
+          userAnswers <- getAnswersFuture("id")
+        } yield userAnswers
+
+        val userAnswers = Await.result(resultUserAnswers, 2.seconds).get
+        ElectionsSectionStatus.getStatus(userAnswers) shouldEqual Completed
+      }
+
+      "Group ratio / Blended with investor group / No active EBITDA / No active interest allowance (alt) / Not interest allowance non-con / Consolidated partnerships" in {
+        AuthStub.authorised()
+
+        setAnswers(emptyUserAnswers)
+
+        val resultUserAnswers = for {
+          _ <- postRequest("/elections/group-ratio-election", Json.obj("value" -> true))()
+          _ <- postRequest("/elections/group-ratio-blended-election", Json.obj("value" -> true))()
+          _ <- postRequest("/elections/investor-group/1/name", Json.obj("value" -> "Investor Name"))()
+          _ <- postRequest("/elections/investor-group/1/ratio-method", Json.obj("value" -> "true"))()
+          _ <- postRequest("/elections/investor-group/1/other-elections", Json.obj("value[0]" -> GroupEBITDA.toString))()
+          _ <- postRequest("/elections/elected-group-ebitda-before", Json.obj("value" -> false))()
+          _ <- postRequest("/elections/group-ebitda-chargeable-gains-election", Json.obj("value" -> true))()
+          _ <- postRequest("/elections/elected-interest-allowance-alternative-calc-before", Json.obj("value" -> false))()
+          _ <- postRequest("/elections/interest-allowance-alternative-calc-election", Json.obj("value" -> false))()
+          _ <- postRequest("/elections/interest-allowance-non-consolidated-investments-election", Json.obj("value" -> false))()
+          _ <- postRequest("/elections/elected-interest-allowance-consolidated-pship-before", Json.obj("value" -> false))()
+          _ <- postRequest("/elections/interest-allowance-consolidated-pship-election", Json.obj("value" -> false))()
+          userAnswers <- getAnswersFuture("id")
+        } yield userAnswers
+
+        val userAnswers = Await.result(resultUserAnswers, 2.seconds).get
+        ElectionsSectionStatus.getStatus(userAnswers) shouldEqual Completed
+      }
+
+      "Not group ratio / Active interest allowance (alt) / Non-con investments / No consolidated partnerships" in {
+        AuthStub.authorised()
+
+        setAnswers(emptyUserAnswers)
+
+        val resultUserAnswers = for {
+          _ <- postRequest("/elections/group-ratio-election", Json.obj("value" -> false))()
+          _ <- postRequest("/elections/elected-interest-allowance-alternative-calc-before", Json.obj("value" -> true))()
+          _ <- postRequest("/elections/interest-allowance-non-consolidated-investments-election", Json.obj("value" -> true))()
+          _ <- postRequest("/elections/investment/1/name", Json.obj("value" -> "name"))()
+          _ <- postRequest("/elections/elected-interest-allowance-consolidated-pship-before", Json.obj("value" -> false))()
+          _ <- postRequest("/elections/interest-allowance-consolidated-pship-election", Json.obj("value" -> false))()
+          userAnswers <- getAnswersFuture("id")
+        } yield userAnswers
+
+        val userAnswers = Await.result(resultUserAnswers, 2.seconds).get
+        ElectionsSectionStatus.getStatus(userAnswers) shouldEqual Completed
+      }
+
+      "Not group ratio / Active interest allowance (alt) / No non-con investments / Consolidated partnerships (UK)" in {
+        AuthStub.authorised()
+
+        setAnswers(emptyUserAnswers)
+
+        val resultUserAnswers = for {
+          _ <- postRequest("/elections/group-ratio-election", Json.obj("value" -> false))()
+          _ <- postRequest("/elections/elected-interest-allowance-alternative-calc-before", Json.obj("value" -> true))()
+          _ <- postRequest("/elections/interest-allowance-non-consolidated-investments-election", Json.obj("value" -> false))()
+          _ <- postRequest("/elections/elected-interest-allowance-consolidated-pship-before", Json.obj("value" -> false))()
+          _ <- postRequest("/elections/interest-allowance-consolidated-pship-election", Json.obj("value" -> true))()
+          _ <- postRequest("/elections/partnership/1/name", Json.obj("value" -> "Name"))()
+          _ <- postRequest("/elections/partnership/1/is-uk", Json.obj("value" -> true))()
+          _ <- postRequest("/elections/partnership/1/sautr", Json.obj("value" -> sautr))()
+          userAnswers <- getAnswersFuture("id")
+        } yield userAnswers
+
+        val userAnswers = Await.result(resultUserAnswers, 2.seconds).get
+        ElectionsSectionStatus.getStatus(userAnswers) shouldEqual Completed
+      }
+
+      "Not group ratio / Active interest allowance (alt) / No non-con investments / Consolidated partnerships (Non UK)" in {
+        AuthStub.authorised()
+
+        setAnswers(emptyUserAnswers)
+
+        val resultUserAnswers = for {
+          _ <- postRequest("/elections/group-ratio-election", Json.obj("value" -> false))()
+          _ <- postRequest("/elections/elected-interest-allowance-alternative-calc-before", Json.obj("value" -> true))()
+          _ <- postRequest("/elections/interest-allowance-non-consolidated-investments-election", Json.obj("value" -> false))()
+          _ <- postRequest("/elections/elected-interest-allowance-consolidated-pship-before", Json.obj("value" -> false))()
+          _ <- postRequest("/elections/interest-allowance-consolidated-pship-election", Json.obj("value" -> true))()
+          _ <- postRequest("/elections/partnership/1/name", Json.obj("value" -> "Name"))()
+          _ <- postRequest("/elections/partnership/1/is-uk", Json.obj("value" -> false))()
+          userAnswers <- getAnswersFuture("id")
+        } yield userAnswers
+
+        val userAnswers = Await.result(resultUserAnswers, 2.seconds).get
+        ElectionsSectionStatus.getStatus(userAnswers) shouldEqual Completed
+      }
+    }
+  }
+}

--- a/it/sectionstatus/UltimateParentCompanySectionStatusISpec.scala
+++ b/it/sectionstatus/UltimateParentCompanySectionStatusISpec.scala
@@ -1,0 +1,169 @@
+/*
+ * Copyright 2021 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package sectionstatus
+
+import models.SectionStatus._
+import assets.BaseITConstants
+import utils.{CreateRequestHelper, CustomMatchers, IntegrationSpecBase}
+import stubs.AuthStub
+import play.api.libs.json._
+import scala.concurrent.duration._
+import scala.concurrent.Await
+
+class UltimateParentCompanySectionStatusISpec extends IntegrationSpecBase with CreateRequestHelper with CustomMatchers with BaseITConstants {
+
+  implicit val ec: scala.concurrent.ExecutionContext = scala.concurrent.ExecutionContext.global
+
+  "UltimateParentCompanySectionStatus" should {
+
+    "return InProgress" when {
+      "has deemed parents is set to false and all but one ultimate parent info are entered for a UK LLP" in {
+
+        AuthStub.authorised()
+
+        setAnswers(emptyUserAnswers)
+
+        val resultUserAnswers = for {
+          _ <- postRequest("/ultimate-parent-company/reporting-company-same-as-parent", Json.obj("value" -> "false"))()
+          _ <- postRequest("/ultimate-parent-company/deemed-parent", Json.obj("value" -> false))()
+          _ <- postRequest("/ultimate-parent-company/1/name", Json.obj("value" -> companyName))()
+          _ <- postRequest("/ultimate-parent-company/1/pay-tax-in-uk", Json.obj("value" -> "true"))()
+          _ <- postRequest("/ultimate-parent-company/1/limited-liability-partnership", Json.obj("value" -> true))()
+          userAnswers <- getAnswersFuture("id")
+        } yield userAnswers
+
+        val userAnswers = Await.result(resultUserAnswers, 2.seconds).get
+        
+        UltimateParentCompanySectionStatus.getStatus(userAnswers) shouldEqual InProgress
+      }
+
+      "has deemed parents is set to true and only one deemed parent is entered" in {
+        AuthStub.authorised()
+
+        setAnswers(emptyUserAnswers)
+
+        val resultUserAnswers = for {
+          _ <- postRequest("/ultimate-parent-company/reporting-company-same-as-parent", Json.obj("value" -> "false"))()
+          _ <- postRequest("/ultimate-parent-company/deemed-parent", Json.obj("value" -> true))()
+          _ <- postRequest("/ultimate-parent-company/1/name", Json.obj("value" -> companyName))()
+          _ <- postRequest("/ultimate-parent-company/1/pay-tax-in-uk", Json.obj("value" -> "true"))()
+          _ <- postRequest("/ultimate-parent-company/1/limited-liability-partnership", Json.obj("value" -> true))()
+          _ <- postRequest("/ultimate-parent-company/1/sautr", Json.obj("value" -> "1111111111"))()
+          userAnswers <- getAnswersFuture("id")
+        } yield userAnswers
+
+        val userAnswers = Await.result(resultUserAnswers, 2.seconds).get
+        UltimateParentCompanySectionStatus.getStatus(userAnswers) shouldEqual InProgress
+      }
+
+      "has deemed parents is set to true and three deemed parents are added but data is missing for the third" in {
+        AuthStub.authorised()
+
+        setAnswers(emptyUserAnswers)
+
+        val resultUserAnswers = for {
+          _ <- postRequest("/ultimate-parent-company/reporting-company-same-as-parent", Json.obj("value" -> "false"))()
+          _ <- postRequest("/ultimate-parent-company/deemed-parent", Json.obj("value" -> true))()
+          _ <- postRequest("/ultimate-parent-company/1/name", Json.obj("value" -> companyName))()
+          _ <- postRequest("/ultimate-parent-company/1/pay-tax-in-uk", Json.obj("value" -> "true"))()
+          _ <- postRequest("/ultimate-parent-company/1/limited-liability-partnership", Json.obj("value" -> true))()
+          _ <- postRequest("/ultimate-parent-company/1/sautr", Json.obj("value" -> "1111111111"))()
+          _ <- postRequest("/ultimate-parent-company/2/name", Json.obj("value" -> companyName))()
+          _ <- postRequest("/ultimate-parent-company/2/pay-tax-in-uk", Json.obj("value" -> "true"))()
+          _ <- postRequest("/ultimate-parent-company/2/limited-liability-partnership", Json.obj("value" -> false))()
+          _ <- postRequest("/ultimate-parent-company/2/ctutr", Json.obj("value" -> "1111111111"))()
+          _ <- postRequest("/ultimate-parent-company/3/name", Json.obj("value" -> companyName))()
+          _ <- postRequest("/ultimate-parent-company/3/pay-tax-in-uk", Json.obj("value" -> "false"))()
+          userAnswers <- getAnswersFuture("id")
+        } yield userAnswers
+
+        val userAnswers = Await.result(resultUserAnswers, 2.seconds).get
+        UltimateParentCompanySectionStatus.getStatus(userAnswers) shouldEqual InProgress
+      }
+    }
+    
+    "return Completed" when {
+      "has deemed parents is set to false and all ultimate parent info is entered for a UK LLP" in {
+        AuthStub.authorised()
+
+        setAnswers(emptyUserAnswers)
+
+        val resultUserAnswers = for {
+          _ <- postRequest("/ultimate-parent-company/reporting-company-same-as-parent", Json.obj("value" -> "false"))()
+          _ <- postRequest("/ultimate-parent-company/deemed-parent", Json.obj("value" -> false))()
+          _ <- postRequest("/ultimate-parent-company/1/name", Json.obj("value" -> companyName))()
+          _ <- postRequest("/ultimate-parent-company/1/pay-tax-in-uk", Json.obj("value" -> "true"))()
+          _ <- postRequest("/ultimate-parent-company/1/limited-liability-partnership", Json.obj("value" -> true))()
+          _ <- postRequest("/ultimate-parent-company/1/sautr", Json.obj("value" -> "1111111111"))()
+          userAnswers <- getAnswersFuture("id")
+        } yield userAnswers
+
+        val userAnswers = Await.result(resultUserAnswers, 2.seconds).get
+        UltimateParentCompanySectionStatus.getStatus(userAnswers) shouldEqual Completed
+      }
+
+      "has deemed parents is set to true and two deemed parents are added" in {
+        AuthStub.authorised()
+
+        setAnswers(emptyUserAnswers)
+
+        val resultUserAnswers = for {
+          _ <- postRequest("/ultimate-parent-company/reporting-company-same-as-parent", Json.obj("value" -> "false"))()
+          _ <- postRequest("/ultimate-parent-company/deemed-parent", Json.obj("value" -> true))()
+          _ <- postRequest("/ultimate-parent-company/1/name", Json.obj("value" -> companyName))()
+          _ <- postRequest("/ultimate-parent-company/1/pay-tax-in-uk", Json.obj("value" -> "true"))()
+          _ <- postRequest("/ultimate-parent-company/1/limited-liability-partnership", Json.obj("value" -> true))()
+          _ <- postRequest("/ultimate-parent-company/1/sautr", Json.obj("value" -> "1111111111"))()
+          _ <- postRequest("/ultimate-parent-company/2/name", Json.obj("value" -> companyName))()
+          _ <- postRequest("/ultimate-parent-company/2/pay-tax-in-uk", Json.obj("value" -> "true"))()
+          _ <- postRequest("/ultimate-parent-company/2/limited-liability-partnership", Json.obj("value" -> false))()
+          _ <- postRequest("/ultimate-parent-company/2/ctutr", Json.obj("value" -> "1111111111"))()
+          userAnswers <- getAnswersFuture("id")
+        } yield userAnswers
+
+        val userAnswers = Await.result(resultUserAnswers, 2.seconds).get
+        UltimateParentCompanySectionStatus.getStatus(userAnswers) shouldEqual Completed
+      }
+
+      "has deemed parents is set to true and three deemed parents are added" in {
+        AuthStub.authorised()
+
+        setAnswers(emptyUserAnswers)
+
+        val resultUserAnswers = for {
+          _ <- postRequest("/ultimate-parent-company/reporting-company-same-as-parent", Json.obj("value" -> "false"))()
+          _ <- postRequest("/ultimate-parent-company/deemed-parent", Json.obj("value" -> true))()
+          _ <- postRequest("/ultimate-parent-company/1/name", Json.obj("value" -> companyName))()
+          _ <- postRequest("/ultimate-parent-company/1/pay-tax-in-uk", Json.obj("value" -> "true"))()
+          _ <- postRequest("/ultimate-parent-company/1/limited-liability-partnership", Json.obj("value" -> true))()
+          _ <- postRequest("/ultimate-parent-company/1/sautr", Json.obj("value" -> "1111111111"))()
+          _ <- postRequest("/ultimate-parent-company/2/name", Json.obj("value" -> companyName))()
+          _ <- postRequest("/ultimate-parent-company/2/pay-tax-in-uk", Json.obj("value" -> "true"))()
+          _ <- postRequest("/ultimate-parent-company/2/limited-liability-partnership", Json.obj("value" -> false))()
+          _ <- postRequest("/ultimate-parent-company/2/ctutr", Json.obj("value" -> "1111111111"))()
+          _ <- postRequest("/ultimate-parent-company/3/name", Json.obj("value" -> companyName))()
+          _ <- postRequest("/ultimate-parent-company/3/pay-tax-in-uk", Json.obj("value" -> "false"))()
+          _ <- postRequest("/ultimate-parent-company/3/country-of-incorporation", Json.obj("value" -> countryOfIncorporation.country))()
+          userAnswers <- getAnswersFuture("id")
+        } yield userAnswers
+
+        val userAnswers = Await.result(resultUserAnswers, 2.seconds).get
+        UltimateParentCompanySectionStatus.getStatus(userAnswers) shouldEqual Completed
+      }
+    }
+  }
+}

--- a/it/utils/IntegrationSpecBase.scala
+++ b/it/utils/IntegrationSpecBase.scala
@@ -8,7 +8,7 @@ import org.scalatest.{TryValues, _}
 import org.scalatestplus.play.guice.GuiceOneServerPerSuite
 import pages.QuestionPage
 import play.api.inject.guice.GuiceApplicationBuilder
-import play.api.libs.json.{Json, Reads, Writes}
+import play.api.libs.json.Json
 import play.api.{Application, Environment, Mode}
 import repositories.SessionRepository
 import stubs.AuthStub
@@ -47,10 +47,10 @@ trait IntegrationSpecBase extends WordSpec
   def getAnswers(id: String)(implicit timeout: Duration): Option[UserAnswers] = Await.result(mongo.get(id), timeout)
   def getAnswersFuture(id: String) = mongo.get(id)
 
-  def setAnswers[A](page: QuestionPage[A], value: A)(implicit writes: Writes[A]): Unit =
+  def setAnswers[A](page: QuestionPage[A], value: A): Unit =
     setAnswers(emptyUserAnswers.set(page, value).success.value)
 
-  def appendList[A](page: QuestionPage[A], value: A)(implicit writes: Writes[A], rds: Reads[A]): Unit = {
+  def appendList[A](page: QuestionPage[A], value: A): Unit = {
     setAnswers(emptyUserAnswers.appendList(page, value).success.value)
   }
 

--- a/it/utils/IntegrationSpecBase.scala
+++ b/it/utils/IntegrationSpecBase.scala
@@ -45,6 +45,7 @@ trait IntegrationSpecBase extends WordSpec
 
   def setAnswers(userAnswers: UserAnswers)(implicit timeout: Duration): Unit = Await.result(mongo.set(userAnswers), timeout)
   def getAnswers(id: String)(implicit timeout: Duration): Option[UserAnswers] = Await.result(mongo.get(id), timeout)
+  def getAnswersFuture(id: String) = mongo.get(id)
 
   def setAnswers[A](page: QuestionPage[A], value: A)(implicit writes: Writes[A]): Unit =
     setAnswers(emptyUserAnswers.set(page, value).success.value)

--- a/test/navigation/AboutReturnNavigatorSpec.scala
+++ b/test/navigation/AboutReturnNavigatorSpec.scala
@@ -22,7 +22,7 @@ import controllers.ultimateParentCompany.{routes => ultimateParentCompanyRoutes}
 import models._
 import pages.Page
 import pages.aboutReturn._
-import pages.groupLevelInformation.{DisallowedAmountPage, GroupSubjectToRestrictionsPage, RevisingReturnPage}
+import pages.groupLevelInformation.RevisingReturnPage
 
 class AboutReturnNavigatorSpec extends SpecBase {
 

--- a/test/sectionstatus/AboutReturnSectionStatusSpec.scala
+++ b/test/sectionstatus/AboutReturnSectionStatusSpec.scala
@@ -34,13 +34,13 @@ class AboutReturnSectionStatusSpec extends SpecBase with BaseConstants {
     "return NotStarted" when {
       "no data from the section has been entered" in {
         val userAnswers = emptyUserAnswers
-        AboutReturnSectionStatus.aboutReturnSectionStatus(userAnswers) mustEqual NotStarted
+        AboutReturnSectionStatus.getStatus(userAnswers) mustEqual NotStarted
       }
     }
     "return InProgress" when {
       "has some data been entered" in {
         val userAnswers = emptyUserAnswers.set(ReportingCompanyAppointedPage, true).get
-        AboutReturnSectionStatus.aboutReturnSectionStatus(userAnswers) mustEqual InProgress
+        AboutReturnSectionStatus.getStatus(userAnswers) mustEqual InProgress
       }
 
       "agent bool is set to true and the agent name isn't populated (and all other data is)" in {
@@ -56,7 +56,7 @@ class AboutReturnSectionStatusSpec extends SpecBase with BaseConstants {
           .set(ReportingCompanyCTUTRPage, ctutrModel.utr).get
           .set(AccountingPeriodPage, AccountingPeriodModel(date, date.plusMonths(1))).get
 
-        AboutReturnSectionStatus.aboutReturnSectionStatus(userAnswers) mustEqual InProgress
+        AboutReturnSectionStatus.getStatus(userAnswers) mustEqual InProgress
       }
 
       "Revising return is set to true and what has changed is not set" in {
@@ -72,7 +72,7 @@ class AboutReturnSectionStatusSpec extends SpecBase with BaseConstants {
           .set(ReportingCompanyCTUTRPage, ctutrModel.utr).get
           .set(AccountingPeriodPage, AccountingPeriodModel(date, date.plusMonths(1))).get
 
-        AboutReturnSectionStatus.aboutReturnSectionStatus(userAnswers) mustEqual InProgress
+        AboutReturnSectionStatus.getStatus(userAnswers) mustEqual InProgress
       }
     }
     
@@ -91,7 +91,7 @@ class AboutReturnSectionStatusSpec extends SpecBase with BaseConstants {
           .set(ReportingCompanyCTUTRPage, ctutrModel.utr).get
           .set(AccountingPeriodPage, AccountingPeriodModel(date, date.plusMonths(1))).get
 
-        AboutReturnSectionStatus.aboutReturnSectionStatus(userAnswers) mustEqual Completed
+        AboutReturnSectionStatus.getStatus(userAnswers) mustEqual Completed
       }
 
       "agent bool is set to false but the agent name isn't populated (and all other data is)" in {
@@ -107,7 +107,7 @@ class AboutReturnSectionStatusSpec extends SpecBase with BaseConstants {
           .set(ReportingCompanyCTUTRPage, ctutrModel.utr).get
           .set(AccountingPeriodPage, AccountingPeriodModel(date, date.plusMonths(1))).get
 
-        AboutReturnSectionStatus.aboutReturnSectionStatus(userAnswers) mustEqual Completed
+        AboutReturnSectionStatus.getStatus(userAnswers) mustEqual Completed
       }
 
       "Revising return is set to false and what has changed is not set" in {
@@ -123,7 +123,7 @@ class AboutReturnSectionStatusSpec extends SpecBase with BaseConstants {
           .set(ReportingCompanyCTUTRPage, ctutrModel.utr).get
           .set(AccountingPeriodPage, AccountingPeriodModel(date, date.plusMonths(1))).get
 
-        AboutReturnSectionStatus.aboutReturnSectionStatus(userAnswers) mustEqual Completed
+        AboutReturnSectionStatus.getStatus(userAnswers) mustEqual Completed
       }
       
     }

--- a/test/sectionstatus/ElectionsSectionStatusSpec.scala
+++ b/test/sectionstatus/ElectionsSectionStatusSpec.scala
@@ -1,0 +1,116 @@
+/*
+ * Copyright 2021 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package sectionstatus
+
+import base.SpecBase
+import models.SectionStatus._
+import pages.elections._
+import assets.constants.BaseConstants
+import models.UserAnswers
+import models.returnModels._
+import models.{InvestorRatioMethod, OtherInvestorGroupElections}
+import models.IsUKPartnershipOrPreferNotToAnswer._
+
+class ElectionsSectionStatusSpec extends SpecBase with BaseConstants {
+
+  "getStatus" must {
+    "return NotStarted" when {
+      "no data from the section has been entered" in {
+        val userAnswers = UserAnswers("id")
+        ElectionsSectionStatus.getStatus(userAnswers) mustEqual NotStarted
+      }
+    }
+  }
+
+  "isInvestorGroupComplete" must {
+    "return true where all data is populated" in {
+      val investorGroup = 
+        InvestorGroupModel(
+          investorName = "name", 
+          ratioMethod = Some(InvestorRatioMethod.GroupRatioMethod), 
+          otherInvestorGroupElections = Some(Set(OtherInvestorGroupElections.GroupRatioBlended))
+        )
+      val userAnswers = UserAnswers("id").set(InvestorGroupsPage, investorGroup, Some(1)).get
+      ElectionsSectionStatus.isInvestorGroupComplete(userAnswers, 1) mustEqual true
+    }
+
+    "return false where the OtherInvestorGroupElections is missing" in {
+      val investorGroup = 
+        InvestorGroupModel(
+          investorName = "name", 
+          ratioMethod = Some(InvestorRatioMethod.GroupRatioMethod), 
+          otherInvestorGroupElections = None
+        )
+      val userAnswers = UserAnswers("id").set(InvestorGroupsPage, investorGroup, Some(1)).get
+      ElectionsSectionStatus.isInvestorGroupComplete(userAnswers, 1) mustEqual false
+    }
+
+    "return false where the ratioMethod and otherInvestorGroupElections is missing" in {
+      val investorGroup = 
+        InvestorGroupModel(
+          investorName = "name", 
+          ratioMethod = None, 
+          otherInvestorGroupElections = None
+        )
+      val userAnswers = UserAnswers("id").set(InvestorGroupsPage, investorGroup, Some(1)).get
+      ElectionsSectionStatus.isInvestorGroupComplete(userAnswers, 1) mustEqual false
+    }
+  }
+
+  "isPartnershipComplete" must {
+    "return true where isUkPartnership is PreferNotToAnswer and sautr is not populated" in {
+      val partnership = 
+        PartnershipModel(
+          name = "name",
+          isUkPartnership = Some(PreferNotToAnswer),
+          sautr = None
+        )
+      
+      val userAnswers = UserAnswers("id").set(PartnershipsPage, partnership, Some(1)).get
+      ElectionsSectionStatus.isPartnershipComplete(userAnswers, 1) mustEqual true
+    }
+
+    "return true where isUkPartnership is answered and sautr is populated" in {
+      val partnership = 
+        PartnershipModel(
+          name = "name",
+          isUkPartnership = Some(IsUkPartnership),
+          sautr = Some(UTRModel("1111111111"))
+        )
+      
+      val userAnswers = UserAnswers("id").set(PartnershipsPage, partnership, Some(1)).get
+      ElectionsSectionStatus.isPartnershipComplete(userAnswers, 1) mustEqual true
+    }
+
+    "return false where isUkPartnership is answered and sautr is not populated" in {
+      val partnership = 
+        PartnershipModel(
+          name = "name",
+          isUkPartnership = Some(IsUkPartnership),
+          sautr = None
+        )
+      
+      val userAnswers = UserAnswers("id").set(PartnershipsPage, partnership, Some(1)).get
+      ElectionsSectionStatus.isPartnershipComplete(userAnswers, 1) mustEqual false
+    }
+
+    "return false where the partnership is not populated" in {
+      val userAnswers = UserAnswers("id")
+      ElectionsSectionStatus.isPartnershipComplete(userAnswers, 1) mustEqual false
+    }
+  }
+}

--- a/test/sectionstatus/ElectionsSectionStatusSpec.scala
+++ b/test/sectionstatus/ElectionsSectionStatusSpec.scala
@@ -18,7 +18,6 @@ package sectionstatus
 
 import base.SpecBase
 import models.SectionStatus._
-import pages.elections._
 import assets.constants.BaseConstants
 import models.UserAnswers
 import models.returnModels._
@@ -44,19 +43,7 @@ class ElectionsSectionStatusSpec extends SpecBase with BaseConstants {
           ratioMethod = Some(InvestorRatioMethod.GroupRatioMethod), 
           otherInvestorGroupElections = Some(Set(OtherInvestorGroupElections.GroupRatioBlended))
         )
-      val userAnswers = UserAnswers("id").set(InvestorGroupsPage, investorGroup, Some(1)).get
-      ElectionsSectionStatus.isInvestorGroupComplete(userAnswers, 1) mustEqual true
-    }
-
-    "return false where the OtherInvestorGroupElections is missing" in {
-      val investorGroup = 
-        InvestorGroupModel(
-          investorName = "name", 
-          ratioMethod = Some(InvestorRatioMethod.GroupRatioMethod), 
-          otherInvestorGroupElections = None
-        )
-      val userAnswers = UserAnswers("id").set(InvestorGroupsPage, investorGroup, Some(1)).get
-      ElectionsSectionStatus.isInvestorGroupComplete(userAnswers, 1) mustEqual false
+      ElectionsSectionStatus.isInvestorGroupComplete(investorGroup) mustEqual true
     }
 
     "return false where the ratioMethod and otherInvestorGroupElections is missing" in {
@@ -66,8 +53,7 @@ class ElectionsSectionStatusSpec extends SpecBase with BaseConstants {
           ratioMethod = None, 
           otherInvestorGroupElections = None
         )
-      val userAnswers = UserAnswers("id").set(InvestorGroupsPage, investorGroup, Some(1)).get
-      ElectionsSectionStatus.isInvestorGroupComplete(userAnswers, 1) mustEqual false
+      ElectionsSectionStatus.isInvestorGroupComplete(investorGroup) mustEqual false
     }
   }
 
@@ -79,9 +65,7 @@ class ElectionsSectionStatusSpec extends SpecBase with BaseConstants {
           isUkPartnership = Some(PreferNotToAnswer),
           sautr = None
         )
-      
-      val userAnswers = UserAnswers("id").set(PartnershipsPage, partnership, Some(1)).get
-      ElectionsSectionStatus.isPartnershipComplete(userAnswers, 1) mustEqual true
+      ElectionsSectionStatus.isPartnershipComplete(partnership) mustEqual true
     }
 
     "return true where isUkPartnership is answered and sautr is populated" in {
@@ -91,9 +75,7 @@ class ElectionsSectionStatusSpec extends SpecBase with BaseConstants {
           isUkPartnership = Some(IsUkPartnership),
           sautr = Some(UTRModel("1111111111"))
         )
-      
-      val userAnswers = UserAnswers("id").set(PartnershipsPage, partnership, Some(1)).get
-      ElectionsSectionStatus.isPartnershipComplete(userAnswers, 1) mustEqual true
+      ElectionsSectionStatus.isPartnershipComplete(partnership) mustEqual true
     }
 
     "return false where isUkPartnership is answered and sautr is not populated" in {
@@ -103,14 +85,8 @@ class ElectionsSectionStatusSpec extends SpecBase with BaseConstants {
           isUkPartnership = Some(IsUkPartnership),
           sautr = None
         )
-      
-      val userAnswers = UserAnswers("id").set(PartnershipsPage, partnership, Some(1)).get
-      ElectionsSectionStatus.isPartnershipComplete(userAnswers, 1) mustEqual false
+      ElectionsSectionStatus.isPartnershipComplete(partnership) mustEqual false
     }
 
-    "return false where the partnership is not populated" in {
-      val userAnswers = UserAnswers("id")
-      ElectionsSectionStatus.isPartnershipComplete(userAnswers, 1) mustEqual false
-    }
   }
 }

--- a/test/sectionstatus/UltimateParentCompanySectionStatusSpec.scala
+++ b/test/sectionstatus/UltimateParentCompanySectionStatusSpec.scala
@@ -1,0 +1,312 @@
+/*
+ * Copyright 2021 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package sectionstatus
+
+import base.SpecBase
+import models.SectionStatus._
+import pages.ultimateParentCompany._
+import pages.Page._
+import assets.constants.BaseConstants
+import models.UserAnswers
+import models.FullOrAbbreviatedReturn._
+import models.returnModels.DeemedParentModel
+import models.returnModels._
+
+class UltimateParentCompanySectionStatusSpec extends SpecBase with BaseConstants {
+
+  "UltimateParentCompanySectionStatus" must {
+    "return NotStarted" when {
+      "no data from the section has been entered" in {
+        val userAnswers = UserAnswers("id")
+        UltimateParentCompanySectionStatus.getStatus(userAnswers) mustEqual NotStarted
+      }
+    }
+    "return InProgress" when {
+      "only ReportingCompanySameAsParent is set and it's set to false" in {
+        val userAnswers = UserAnswers("id").set(ReportingCompanySameAsParentPage, false).get
+        UltimateParentCompanySectionStatus.getStatus(userAnswers) mustEqual InProgress
+      }
+  
+      "has deemed parents is set to false and all but one ultimate parent info are entered for a UK LLP" in {
+        val deemedParentModel = 
+          DeemedParentModel(
+            companyName = CompanyNameModel("Name"),
+            limitedLiabilityPartnership = Some(true),
+            payTaxInUk = Some(true),
+            reportingCompanySameAsParent = Some(false)
+          )
+        val userAnswers = UserAnswers("id")
+            .set(ReportingCompanySameAsParentPage, false).get
+            .set(HasDeemedParentPage, false).get
+            .set(DeemedParentPage, deemedParentModel, Some(1)).get
+        
+        UltimateParentCompanySectionStatus.getStatus(userAnswers) mustEqual InProgress
+      }
+
+      "has deemed parents is set to false and all but one ultimate parent info are entered for a UK Co" in {
+        val deemedParentModel = 
+          DeemedParentModel(
+            companyName = CompanyNameModel("Name"),
+            limitedLiabilityPartnership = Some(false),
+            payTaxInUk = Some(true),
+            reportingCompanySameAsParent = Some(false)
+          )
+        val userAnswers = UserAnswers("id")
+            .set(ReportingCompanySameAsParentPage, false).get
+            .set(HasDeemedParentPage, false).get
+            .set(DeemedParentPage, deemedParentModel, Some(1)).get
+        
+        UltimateParentCompanySectionStatus.getStatus(userAnswers) mustEqual InProgress
+      }
+
+      "has deemed parents is set to false and all but one ultimate parent info are entered for a non UK Co" in {
+        val deemedParentModel = 
+          DeemedParentModel(
+            companyName = CompanyNameModel("Name"),
+            payTaxInUk = Some(false),
+            reportingCompanySameAsParent = Some(false)
+          )
+        val userAnswers = UserAnswers("id")
+            .set(ReportingCompanySameAsParentPage, false).get
+            .set(HasDeemedParentPage, false).get
+            .set(DeemedParentPage, deemedParentModel, Some(1)).get
+        
+        UltimateParentCompanySectionStatus.getStatus(userAnswers) mustEqual InProgress
+      }
+
+      "has deemed parents is set to true and only part of a deemed parent is entered" in {
+        val deemedParentModel = 
+          DeemedParentModel(
+            companyName = CompanyNameModel("Name"),
+            payTaxInUk = Some(false),
+            reportingCompanySameAsParent = Some(false)
+          )
+        val userAnswers = UserAnswers("id")
+            .set(ReportingCompanySameAsParentPage, false).get
+            .set(HasDeemedParentPage, true).get
+            .set(DeemedParentPage, deemedParentModel, Some(1)).get
+        
+        UltimateParentCompanySectionStatus.getStatus(userAnswers) mustEqual InProgress
+      }
+
+      "has deemed parents is set to true and only one deemed parent is entered" in {
+        val deemedParentModel = 
+          DeemedParentModel(
+            companyName = CompanyNameModel("Name"),
+            sautr = Some(UTRModel("1123456789")),
+            limitedLiabilityPartnership = Some(true),
+            payTaxInUk = Some(true),
+            reportingCompanySameAsParent = Some(false)
+          )
+        val userAnswers = UserAnswers("id")
+            .set(ReportingCompanySameAsParentPage, false).get
+            .set(HasDeemedParentPage, true).get
+            .set(DeemedParentPage, deemedParentModel, Some(1)).get
+        
+        UltimateParentCompanySectionStatus.getStatus(userAnswers) mustEqual InProgress
+      }
+
+      "has deemed parents is set to true and two deemed parents are added, but one is incomplete" in {
+        val deemedParentModel1 = 
+          DeemedParentModel(
+            companyName = CompanyNameModel("Name"),
+            sautr = Some(UTRModel("1123456789")),
+            limitedLiabilityPartnership = Some(true),
+            payTaxInUk = Some(true),
+            reportingCompanySameAsParent = Some(false)
+          )
+
+        val deemedParentModel2 = 
+          DeemedParentModel(
+            companyName = CompanyNameModel("Name"),
+            limitedLiabilityPartnership = Some(false),
+            payTaxInUk = Some(true),
+            reportingCompanySameAsParent = Some(false)
+          )
+
+        val userAnswers = 
+          UserAnswers("id")
+            .set(ReportingCompanySameAsParentPage, false).get
+            .set(HasDeemedParentPage, true).get
+            .set(DeemedParentPage, deemedParentModel1, Some(1)).get
+            .set(DeemedParentPage, deemedParentModel2, Some(2)).get
+        
+        UltimateParentCompanySectionStatus.getStatus(userAnswers) mustEqual InProgress
+      }
+
+      "has deemed parents is set to true and three deemed parents are added, but one is incomplete" in {
+        val deemedParentModel1 = 
+          DeemedParentModel(
+            companyName = CompanyNameModel("Name"),
+            sautr = Some(UTRModel("1123456789")),
+            limitedLiabilityPartnership = Some(true),
+            payTaxInUk = Some(true),
+            reportingCompanySameAsParent = Some(false)
+          )
+
+          val deemedParentModel2 = 
+          DeemedParentModel(
+            companyName = CompanyNameModel("Name"),
+            ctutr = Some(UTRModel("1123456789")),
+            limitedLiabilityPartnership = Some(false),
+            payTaxInUk = Some(true),
+            reportingCompanySameAsParent = Some(false)
+          )
+
+        val deemedParentModel3 = 
+          DeemedParentModel(
+            companyName = CompanyNameModel("Name"),
+            payTaxInUk = Some(false),
+            reportingCompanySameAsParent = Some(false)
+          )
+
+        val userAnswers = UserAnswers("id")
+            .set(ReportingCompanySameAsParentPage, false).get
+            .set(HasDeemedParentPage, true).get
+            .set(DeemedParentPage, deemedParentModel1, Some(1)).get
+            .set(DeemedParentPage, deemedParentModel2, Some(2)).get
+            .set(DeemedParentPage, deemedParentModel3, Some(3)).get
+        
+        UltimateParentCompanySectionStatus.getStatus(userAnswers) mustEqual InProgress
+      }
+    }
+    
+    "return Completed" when {
+      "only ReportingCompanySameAsParent is set and it's set to false" in {
+        val userAnswers = UserAnswers("id").set(ReportingCompanySameAsParentPage, true).get
+        UltimateParentCompanySectionStatus.getStatus(userAnswers) mustEqual Completed
+      }
+
+      "has deemed parents is set to false and all ultimate parent info are entered for a UK LLP" in {
+        val deemedParentModel = 
+          DeemedParentModel(
+            companyName = CompanyNameModel("Name"),
+            sautr = Some(UTRModel("1123456789")),
+            limitedLiabilityPartnership = Some(true),
+            payTaxInUk = Some(true),
+            reportingCompanySameAsParent = Some(false)
+          )
+        val userAnswers = UserAnswers("id")
+            .set(ReportingCompanySameAsParentPage, false).get
+            .set(HasDeemedParentPage, false).get
+            .set(DeemedParentPage, deemedParentModel, Some(1)).get
+        
+        UltimateParentCompanySectionStatus.getStatus(userAnswers) mustEqual Completed
+      }
+
+      "has deemed parents is set to false and all ultimate parent info are entered for a UK Co" in {
+        val deemedParentModel = 
+          DeemedParentModel(
+            companyName = CompanyNameModel("Name"),
+            ctutr = Some(UTRModel("1123456789")),
+            limitedLiabilityPartnership = Some(false),
+            payTaxInUk = Some(true),
+            reportingCompanySameAsParent = Some(false)
+          )
+        val userAnswers = UserAnswers("id")
+            .set(ReportingCompanySameAsParentPage, false).get
+            .set(HasDeemedParentPage, false).get
+            .set(DeemedParentPage, deemedParentModel, Some(1)).get
+        
+        UltimateParentCompanySectionStatus.getStatus(userAnswers) mustEqual Completed
+      }
+
+      "has deemed parents is set to false and all ultimate parent info are entered for a non UK Co" in {
+        val deemedParentModel = 
+          DeemedParentModel(
+            companyName = CompanyNameModel("Name"),
+            countryOfIncorporation = Some(CountryCodeModel("ES", "Spain")),
+            limitedLiabilityPartnership = Some(false),
+            payTaxInUk = Some(false),
+            reportingCompanySameAsParent = Some(false)
+          )
+        val userAnswers = UserAnswers("id")
+            .set(ReportingCompanySameAsParentPage, false).get
+            .set(HasDeemedParentPage, false).get
+            .set(DeemedParentPage, deemedParentModel, Some(1)).get
+        
+        UltimateParentCompanySectionStatus.getStatus(userAnswers) mustEqual Completed
+      }
+
+      "has deemed parents is set to true and two deemed parents are added" in {
+        val deemedParentModel1 = 
+          DeemedParentModel(
+            companyName = CompanyNameModel("Name"),
+            sautr = Some(UTRModel("1123456789")),
+            limitedLiabilityPartnership = Some(true),
+            payTaxInUk = Some(true),
+            reportingCompanySameAsParent = Some(false)
+          )
+
+        val deemedParentModel2 = 
+          DeemedParentModel(
+            companyName = CompanyNameModel("Name"),
+            ctutr = Some(UTRModel("1123456789")),
+            limitedLiabilityPartnership = Some(false),
+            payTaxInUk = Some(true),
+            reportingCompanySameAsParent = Some(false)
+          )
+
+        val userAnswers = UserAnswers("id")
+            .set(ReportingCompanySameAsParentPage, false).get
+            .set(HasDeemedParentPage, true).get
+            .set(DeemedParentPage, deemedParentModel1, Some(1)).get
+            .set(DeemedParentPage, deemedParentModel2, Some(2)).get
+        
+        UltimateParentCompanySectionStatus.getStatus(userAnswers) mustEqual Completed
+      }
+
+      "has deemed parents is set to true and three deemed parents are added" in {
+        val deemedParentModel1 = 
+          DeemedParentModel(
+            companyName = CompanyNameModel("Name"),
+            sautr = Some(UTRModel("1123456789")),
+            limitedLiabilityPartnership = Some(true),
+            payTaxInUk = Some(true),
+            reportingCompanySameAsParent = Some(false)
+          )
+
+        val deemedParentModel2 = 
+          DeemedParentModel(
+            companyName = CompanyNameModel("Name"),
+            ctutr = Some(UTRModel("1123456789")),
+            limitedLiabilityPartnership = Some(false),
+            payTaxInUk = Some(true),
+            reportingCompanySameAsParent = Some(false)
+          )
+
+        val deemedParentModel3 = 
+          DeemedParentModel(
+            companyName = CompanyNameModel("Name"),
+            countryOfIncorporation = Some(CountryCodeModel("ES", "Spain")),
+            payTaxInUk = Some(false),
+            reportingCompanySameAsParent = Some(false)
+          )
+
+        val userAnswers = UserAnswers("id")
+            .set(ReportingCompanySameAsParentPage, false).get
+            .set(HasDeemedParentPage, true).get
+            .set(DeemedParentPage, deemedParentModel1, Some(1)).get
+            .set(DeemedParentPage, deemedParentModel2, Some(2)).get
+            .set(DeemedParentPage, deemedParentModel3, Some(3)).get
+        
+        UltimateParentCompanySectionStatus.getStatus(userAnswers) mustEqual Completed
+      }
+
+    }
+  }
+}


### PR DESCRIPTION
**Not Started**
In order to determine if a section is not started, we take the list of pages for that section, collect the the QuestionPages, get each of those from the UserAnswers, and then flatten and check if the list is empty.

In order to accommodate this we've moved the implicit Reads/Writes from the UserAnswers.get parameter list, and now we get it from the QuestionPages themselves - each page must define a reads and a writes which it can get implicitly.

**Section models**
Each section is now represented by a data model which we use to determine completion, but will also be reusable in the mapping exercise to quickly fetch the current data for the section.

**CurrentSectionStatus**
Each section status object now extends CurrentSectionStatus which defines the common functionality. The user then only needs to define the pages for a section (usually importing from Page), how to retrieve the current section model, and the isComplete method where we successfully instantiate the section model.

**Integration tests**
We are driving the coding of this functionality by integration tests rather than unit tests, having unit tests cover only individual methods in the object. The reason behind this is that it ensures that our data completion isn't based only on an assumed structure of the UserAnswers object, but the actual resulting data as produced by the controllers of a journey.

In the ParentCompany section, I drove development by the unit tests but then copied almost all of the unit test scenarios to the integration tests so for section 3 I drove primarily from the integration tests. Section 1 is simple enough to be covered by unit tests.


** Consideration **
Please take an extra close look at the logic of the SectionStatus objects and their integration tests in particular.
app/sectionstatus/AboutReturnSectionStatus.scala
app/sectionstatus/UltimateParentCompanySectionStatus.scala
app/sectionstatus/ElectionsSectionStatus.scala