### PR TITLE
CIR-1177 - Plug section statuses into ReviewAndCompletePage

### DIFF
--- a/app/controllers/reviewAndComplete/ReviewAndCompleteController.scala
+++ b/app/controllers/reviewAndComplete/ReviewAndCompleteController.scala
@@ -46,12 +46,12 @@ class ReviewAndCompleteController @Inject()(override val messagesApi: MessagesAp
 
   def onPageLoad: Action[AnyContent] = (identify andThen getData andThen requireData).async { implicit request =>
     val reviewAndCompleteHelper = new ReviewAndCompleteHelper()
-    val reviewAndCompleteModel = ReviewAndCompleteModel()
+    val reviewAndCompleteModel = ReviewAndCompleteModel(request.userAnswers)
 
-      Future.successful(Ok(view(
-        taskListRows = reviewAndCompleteHelper.rows(reviewAndCompleteModel, request.userAnswers),
-        postAction = routes.ReviewAndCompleteController.onSubmit()
-      )))
+    Future.successful(Ok(view(
+      taskListRows = reviewAndCompleteHelper.rows(reviewAndCompleteModel, request.userAnswers),
+      postAction = routes.ReviewAndCompleteController.onSubmit()
+    )))
 
   }
 

--- a/app/models/returnModels/ReviewAndCompleteModel.scala
+++ b/app/models/returnModels/ReviewAndCompleteModel.scala
@@ -17,12 +17,12 @@
 package models.returnModels
 
 import models.SectionStatus.NotStarted
-import models.{Section, SectionStatus}
-import pages.Page
+import models.SectionStatus
 import play.api.libs.json.{Format, Json}
+import sectionstatus._
+import models.UserAnswers
 
-
-case class SectionState(status: SectionStatus = NotStarted, lastPageSaved: Option[Page] = None)
+case class SectionState(status: SectionStatus = NotStarted)
 
 object SectionState {
   implicit val fmt: Format[SectionState] = Json.format[SectionState]
@@ -34,20 +34,26 @@ case class ReviewAndCompleteModel(aboutReturn: SectionState = SectionState(),
                                   ultimateParentCompany: SectionState = SectionState(),
                                   ukCompanies: SectionState = SectionState(),
                                   checkTotals: SectionState = SectionState()) {
-
-  def update(section: Section, sectionStatus: SectionStatus, page: Page): ReviewAndCompleteModel = section match {
-    case Section.AboutReturn => this.copy(aboutReturn = SectionState(sectionStatus, Some(page)))
-    case Section.Elections => this.copy(elections = SectionState(sectionStatus, Some(page)))
-    case Section.GroupLevelInformation => this.copy(groupLevelInformation = SectionState(sectionStatus, Some(page)))
-    case Section.UltimateParentCompany => this.copy(ultimateParentCompany = SectionState(sectionStatus, Some(page)))
-    case Section.UkCompanies => this.copy(ukCompanies = SectionState(sectionStatus, Some(page)))
-    case Section.CheckTotals => this.copy(checkTotals = SectionState(sectionStatus, Some(page)))
-    case Section.ReviewTaxEBITDA => throw new Exception("Not yet implemented")
-    case Section.ReviewReactivations => throw new Exception("Not yet implemented")
-    case Section.ReviewAndComplete => throw new Exception("Not yet implemented")
-  }
 }
 
 object ReviewAndCompleteModel {
   implicit val format = Json.format[ReviewAndCompleteModel]
+
+  def apply(userAnswers: UserAnswers): ReviewAndCompleteModel = {
+
+    val aboutReturnStatus = AboutReturnSectionStatus.getStatus(userAnswers)
+    val electionsStatus = ElectionsSectionStatus.getStatus(userAnswers)
+    val groupLevelInformationStatus = GroupLevelInformationSectionStatus.getStatus(userAnswers)
+    val ultimateParentCompanyStatus = UltimateParentCompanySectionStatus.getStatus(userAnswers)
+    val ukCompaniesStatus = UltimateParentCompanySectionStatus.getStatus(userAnswers)
+
+    ReviewAndCompleteModel(
+      aboutReturn = SectionState(aboutReturnStatus),
+      elections = SectionState(electionsStatus),
+      groupLevelInformation = SectionState(groupLevelInformationStatus),
+      ultimateParentCompany = SectionState(ultimateParentCompanyStatus),
+      ukCompanies = SectionState(ukCompaniesStatus),
+      checkTotals = SectionState()
+    )
+  }
 }

--- a/app/models/returnModels/ReviewAndCompleteModel.scala
+++ b/app/models/returnModels/ReviewAndCompleteModel.scala
@@ -16,24 +16,18 @@
 
 package models.returnModels
 
-import models.SectionStatus.NotStarted
 import models.SectionStatus
-import play.api.libs.json.{Format, Json}
+import models.SectionStatus.NotStarted
+import play.api.libs.json.Json
 import sectionstatus._
 import models.UserAnswers
 
-case class SectionState(status: SectionStatus = NotStarted)
-
-object SectionState {
-  implicit val fmt: Format[SectionState] = Json.format[SectionState]
-}
-
-case class ReviewAndCompleteModel(aboutReturn: SectionState = SectionState(),
-                                  elections: SectionState = SectionState(),
-                                  groupLevelInformation: SectionState = SectionState(),
-                                  ultimateParentCompany: SectionState = SectionState(),
-                                  ukCompanies: SectionState = SectionState(),
-                                  checkTotals: SectionState = SectionState()) {
+case class ReviewAndCompleteModel(aboutReturnStatus: SectionStatus = NotStarted,
+                                  electionsStatus: SectionStatus = NotStarted,
+                                  groupLevelInformationStatus: SectionStatus = NotStarted,
+                                  ultimateParentCompanyStatus: SectionStatus = NotStarted,
+                                  ukCompaniesStatus: SectionStatus = NotStarted,
+                                  checkTotalsStatus: SectionStatus = NotStarted) {
 }
 
 object ReviewAndCompleteModel {
@@ -45,15 +39,16 @@ object ReviewAndCompleteModel {
     val electionsStatus = ElectionsSectionStatus.getStatus(userAnswers)
     val groupLevelInformationStatus = GroupLevelInformationSectionStatus.getStatus(userAnswers)
     val ultimateParentCompanyStatus = UltimateParentCompanySectionStatus.getStatus(userAnswers)
-    val ukCompaniesStatus = UltimateParentCompanySectionStatus.getStatus(userAnswers)
+    val ukCompaniesStatus = UkCompaniesSectionStatus.getStatus(userAnswers)
+    val checkTotalsStatus = CheckTotalsSectionStatus.getStatus(userAnswers)
 
     ReviewAndCompleteModel(
-      aboutReturn = SectionState(aboutReturnStatus),
-      elections = SectionState(electionsStatus),
-      groupLevelInformation = SectionState(groupLevelInformationStatus),
-      ultimateParentCompany = SectionState(ultimateParentCompanyStatus),
-      ukCompanies = SectionState(ukCompaniesStatus),
-      checkTotals = SectionState()
+      aboutReturnStatus = aboutReturnStatus,
+      electionsStatus = electionsStatus,
+      groupLevelInformationStatus = groupLevelInformationStatus,
+      ultimateParentCompanyStatus = ultimateParentCompanyStatus,
+      ukCompaniesStatus = ukCompaniesStatus,
+      checkTotalsStatus = checkTotalsStatus
     )
   }
 }

--- a/app/models/sections/CheckTotalsSectionModel.scala
+++ b/app/models/sections/CheckTotalsSectionModel.scala
@@ -1,0 +1,19 @@
+/*
+ * Copyright 2021 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package models.sections
+
+case class CheckTotalsSectionModel()

--- a/app/models/sections/UkCompaniesSectionModel.scala
+++ b/app/models/sections/UkCompaniesSectionModel.scala
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2021 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package models.sections
+
+import models.{FullOrAbbreviatedReturn, CompanyDetailsModel}
+
+case class UkCompaniesSectionModel(
+  ukCompanies: Seq[UkCompanyJourneyModel],
+  fullOrAbbreviatedReturn: FullOrAbbreviatedReturn,
+  subjectToRestrictions: Option[Boolean],
+  subjectToReactivations: Option[Boolean]
+)
+
+case class UkCompanyJourneyModel(
+  companyDetails: CompanyDetailsModel,
+  companyTaxEBITDA: Option[BigDecimal],
+  netTaxInterestIncome: Option[BigDecimal],
+  netTaxInterestExpense: Option[BigDecimal],
+  reactivationAmount: Option[BigDecimal]
+)

--- a/app/sectionstatus/CheckTotalsSectionStatus.scala
+++ b/app/sectionstatus/CheckTotalsSectionStatus.scala
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2021 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package sectionstatus
+
+import models.sections.CheckTotalsSectionModel
+import models._
+import pages.Page._
+
+object CheckTotalsSectionStatus extends CurrentSectionStatus[CheckTotalsSectionModel] {
+
+  val pages = checkTotalsSectionPages
+
+  def isComplete(section: CheckTotalsSectionModel): Boolean = false
+  
+  def currentSection(userAnswers: UserAnswers): Option[CheckTotalsSectionModel] = None
+
+}

--- a/app/sectionstatus/UkCompaniesSectionStatus.scala
+++ b/app/sectionstatus/UkCompaniesSectionStatus.scala
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2021 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package sectionstatus
+
+import models.sections.UkCompaniesSectionModel
+import models._
+import pages.Page._
+
+object UkCompaniesSectionStatus extends CurrentSectionStatus[UkCompaniesSectionModel] {
+
+  val pages = ukCompaniesSectionPages
+
+  def isComplete(section: UkCompaniesSectionModel): Boolean = false
+  
+  def currentSection(userAnswers: UserAnswers): Option[UkCompaniesSectionModel] = None
+
+}

--- a/app/utils/ReviewAndCompleteHelper.scala
+++ b/app/utils/ReviewAndCompleteHelper.scala
@@ -36,32 +36,32 @@ class ReviewAndCompleteHelper(implicit val messages: Messages) {
       TaskListRow(
         messages(s"section.${Section.AboutReturn}"),
         controllers.aboutReturn.routes.CheckAnswersAboutReturnController.onPageLoad(),
-        messages(s"reviewAndComplete.${reviewAndCompleteModel.aboutReturn.status}")
+        messages(s"reviewAndComplete.${reviewAndCompleteModel.aboutReturnStatus}")
       ),
       TaskListRow(
         messages(s"section.${Section.UltimateParentCompany}"),
         ultimateParentLink,
-        messages(s"reviewAndComplete.${reviewAndCompleteModel.ultimateParentCompany.status}")
+        messages(s"reviewAndComplete.${reviewAndCompleteModel.ultimateParentCompanyStatus}")
       ),
       TaskListRow(
         messages(s"section.${Section.Elections}"),
         controllers.elections.routes.CheckAnswersElectionsController.onPageLoad(),
-        messages(s"reviewAndComplete.${reviewAndCompleteModel.elections.status}")
+        messages(s"reviewAndComplete.${reviewAndCompleteModel.electionsStatus}")
       ),
       TaskListRow(
         messages(s"section.${Section.GroupLevelInformation}"),
         controllers.routes.UnderConstructionController.onPageLoad(),
-        messages(s"reviewAndComplete.${reviewAndCompleteModel.groupLevelInformation.status}")
+        messages(s"reviewAndComplete.${reviewAndCompleteModel.groupLevelInformationStatus}")
       ),
       TaskListRow(
         messages(s"section.${Section.UkCompanies}"),
         controllers.ukCompanies.routes.UkCompaniesReviewAnswersListController.onPageLoad(),
-        messages(s"reviewAndComplete.${reviewAndCompleteModel.ukCompanies.status}")
+        messages(s"reviewAndComplete.${reviewAndCompleteModel.ukCompaniesStatus}")
       ),
       TaskListRow(
         messages(s"section.${Section.CheckTotals}"),
         controllers.checkTotals.routes.DerivedCompanyController.onPageLoad(),
-        messages(s"reviewAndComplete.${reviewAndCompleteModel.checkTotals.status}")
+        messages(s"reviewAndComplete.${reviewAndCompleteModel.checkTotalsStatus}")
       )
     )
   }

--- a/it/controllers/ukCompanies/UkCompaniesReviewAnswersListControllerISpec.scala
+++ b/it/controllers/ukCompanies/UkCompaniesReviewAnswersListControllerISpec.scala
@@ -19,7 +19,7 @@ package controllers.ukCompanies
 import assets.UkCompanyITConstants._
 import assets.{BaseITConstants, PageTitles}
 import models.{NormalMode, SectionStatus}
-import models.returnModels.{ReviewAndCompleteModel, SectionState}
+import models.returnModels.ReviewAndCompleteModel
 import pages.ultimateParentCompany.HasDeemedParentPage
 import pages.reviewAndComplete.ReviewAndCompletePage
 import pages.ukCompanies.UkCompaniesPage
@@ -131,7 +131,7 @@ class UkCompaniesReviewAnswersListControllerISpec extends IntegrationSpecBase wi
             val userAnswers = emptyUserAnswers
               .set(HasDeemedParentPage, false).success.value
               .set(UkCompaniesPage, ukCompanyModelMax, Some(1)).success.value
-              .set(ReviewAndCompletePage, ReviewAndCompleteModel(ukCompanies = SectionStatus.InProgress)).success.value
+              .set(ReviewAndCompletePage, ReviewAndCompleteModel(ukCompaniesStatus = SectionStatus.InProgress)).success.value
 
 
             setAnswers(userAnswers)

--- a/it/controllers/ukCompanies/UkCompaniesReviewAnswersListControllerISpec.scala
+++ b/it/controllers/ukCompanies/UkCompaniesReviewAnswersListControllerISpec.scala
@@ -131,7 +131,7 @@ class UkCompaniesReviewAnswersListControllerISpec extends IntegrationSpecBase wi
             val userAnswers = emptyUserAnswers
               .set(HasDeemedParentPage, false).success.value
               .set(UkCompaniesPage, ukCompanyModelMax, Some(1)).success.value
-              .set(ReviewAndCompletePage, ReviewAndCompleteModel(ukCompanies = SectionState(SectionStatus.InProgress))).success.value
+              .set(ReviewAndCompletePage, ReviewAndCompleteModel(ukCompanies = SectionStatus.InProgress)).success.value
 
 
             setAnswers(userAnswers)

--- a/it/controllers/ukCompanies/UkCompaniesReviewAnswersListControllerISpec.scala
+++ b/it/controllers/ukCompanies/UkCompaniesReviewAnswersListControllerISpec.scala
@@ -131,7 +131,7 @@ class UkCompaniesReviewAnswersListControllerISpec extends IntegrationSpecBase wi
             val userAnswers = emptyUserAnswers
               .set(HasDeemedParentPage, false).success.value
               .set(UkCompaniesPage, ukCompanyModelMax, Some(1)).success.value
-              .set(ReviewAndCompletePage, ReviewAndCompleteModel(ukCompanies = SectionState(SectionStatus.InProgress, Some(HasDeemedParentPage)))).success.value
+              .set(ReviewAndCompletePage, ReviewAndCompleteModel(ukCompanies = SectionState(SectionStatus.InProgress))).success.value
 
 
             setAnswers(userAnswers)

--- a/test/assets/constants/ReviewAndCompleteConstants.scala
+++ b/test/assets/constants/ReviewAndCompleteConstants.scala
@@ -19,20 +19,17 @@ package assets.constants
 import models.SectionStatus
 import models.SectionStatus.{Completed, InProgress, NotStarted}
 import models.returnModels.{ReviewAndCompleteModel, SectionState}
-import pages.elections.GroupRatioBlendedElectionPage
-import pages.groupLevelInformation.GroupInterestCapacityPage
-import pages.ukCompanies.{DerivedCompanyPage, UkCompaniesPage}
 import play.api.libs.json.{JsObject, Json}
 
 object ReviewAndCompleteConstants {
 
   val reviewAndCompleteModel: ReviewAndCompleteModel = ReviewAndCompleteModel(
-    aboutReturn = SectionState(NotStarted, None),
-    elections = SectionState(InProgress, Some(GroupRatioBlendedElectionPage)),
-    groupLevelInformation = SectionState(Completed, Some(GroupInterestCapacityPage)),
-    ultimateParentCompany = SectionState(NotStarted, None),
-    ukCompanies = SectionState(InProgress, Some(UkCompaniesPage)),
-    checkTotals = SectionState(Completed, Some(DerivedCompanyPage))
+    aboutReturn = SectionState(NotStarted),
+    elections = SectionState(InProgress),
+    groupLevelInformation = SectionState(Completed),
+    ultimateParentCompany = SectionState(NotStarted),
+    ukCompanies = SectionState(InProgress),
+    checkTotals = SectionState(Completed)
   )
 
   val reviewAndCompleteJson: JsObject = Json.obj(
@@ -40,23 +37,19 @@ object ReviewAndCompleteConstants {
       "status" -> SectionStatus.NotStarted.toString
     ),
     "elections" -> Json.obj(
-      "status" -> SectionStatus.InProgress.toString,
-      "lastPageSaved" -> GroupRatioBlendedElectionPage.toString
+      "status" -> SectionStatus.InProgress.toString
     ),
     "groupLevelInformation" -> Json.obj(
-      "status" -> SectionStatus.Completed.toString,
-      "lastPageSaved" -> GroupInterestCapacityPage.toString
+      "status" -> SectionStatus.Completed.toString
     ),
     "ultimateParentCompany" -> Json.obj(
       "status" -> SectionStatus.NotStarted.toString
     ),
     "ukCompanies" -> Json.obj(
-      "status" -> SectionStatus.InProgress.toString,
-      "lastPageSaved" -> UkCompaniesPage.toString
+      "status" -> SectionStatus.InProgress.toString
     ),
     "checkTotals" -> Json.obj(
-      "status" -> SectionStatus.Completed.toString,
-      "lastPageSaved" -> DerivedCompanyPage.toString
+      "status" -> SectionStatus.Completed.toString
     )
   )
 

--- a/test/assets/constants/ReviewAndCompleteConstants.scala
+++ b/test/assets/constants/ReviewAndCompleteConstants.scala
@@ -18,39 +18,27 @@ package assets.constants
 
 import models.SectionStatus
 import models.SectionStatus.{Completed, InProgress, NotStarted}
-import models.returnModels.{ReviewAndCompleteModel, SectionState}
+import models.returnModels.ReviewAndCompleteModel
 import play.api.libs.json.{JsObject, Json}
 
 object ReviewAndCompleteConstants {
 
   val reviewAndCompleteModel: ReviewAndCompleteModel = ReviewAndCompleteModel(
-    aboutReturn = SectionState(NotStarted),
-    elections = SectionState(InProgress),
-    groupLevelInformation = SectionState(Completed),
-    ultimateParentCompany = SectionState(NotStarted),
-    ukCompanies = SectionState(InProgress),
-    checkTotals = SectionState(Completed)
+    aboutReturnStatus = NotStarted,
+    electionsStatus = InProgress,
+    groupLevelInformationStatus = Completed,
+    ultimateParentCompanyStatus = NotStarted,
+    ukCompaniesStatus = InProgress,
+    checkTotalsStatus = Completed
   )
 
   val reviewAndCompleteJson: JsObject = Json.obj(
-    "aboutReturn" -> Json.obj(
-      "status" -> SectionStatus.NotStarted.toString
-    ),
-    "elections" -> Json.obj(
-      "status" -> SectionStatus.InProgress.toString
-    ),
-    "groupLevelInformation" -> Json.obj(
-      "status" -> SectionStatus.Completed.toString
-    ),
-    "ultimateParentCompany" -> Json.obj(
-      "status" -> SectionStatus.NotStarted.toString
-    ),
-    "ukCompanies" -> Json.obj(
-      "status" -> SectionStatus.InProgress.toString
-    ),
-    "checkTotals" -> Json.obj(
-      "status" -> SectionStatus.Completed.toString
-    )
+    "aboutReturnStatus" -> SectionStatus.NotStarted.toString,
+    "electionsStatus" -> SectionStatus.InProgress.toString,
+    "groupLevelInformationStatus" -> SectionStatus.Completed.toString,
+    "ultimateParentCompanyStatus" -> SectionStatus.NotStarted.toString,
+    "ukCompaniesStatus" -> SectionStatus.InProgress.toString,
+    "checkTotalsStatus" -> SectionStatus.Completed.toString
   )
 
 }

--- a/test/controllers/ukCompanies/UkCompaniesReviewAnswersListControllerSpec.scala
+++ b/test/controllers/ukCompanies/UkCompaniesReviewAnswersListControllerSpec.scala
@@ -23,7 +23,7 @@ import base.SpecBase
 import config.featureSwitch.FeatureSwitching
 import controllers.actions._
 import forms.ukCompanies.UkCompaniesReviewAnswersListFormProvider
-import models.returnModels.{ReviewAndCompleteModel, SectionState}
+import models.returnModels.ReviewAndCompleteModel
 import models.{NormalMode, SectionStatus}
 import navigation.FakeNavigators.FakeUkCompaniesNavigator
 import pages.reviewAndComplete.ReviewAndCompletePage
@@ -101,7 +101,7 @@ class UkCompaniesReviewAnswersListControllerSpec extends SpecBase with FeatureSw
         "redirect to the Next Page route" in {
 
           mockGetAnswers(Some(emptyUserAnswers
-            .set(ReviewAndCompletePage, ReviewAndCompleteModel(ukCompanies = SectionState(SectionStatus.InProgress))).get
+            .set(ReviewAndCompletePage, ReviewAndCompleteModel(ukCompaniesStatus = SectionStatus.InProgress)).get
           ))
 
           val request = fakeRequest.withFormUrlEncodedBody(("value", "false"))

--- a/test/controllers/ukCompanies/UkCompaniesReviewAnswersListControllerSpec.scala
+++ b/test/controllers/ukCompanies/UkCompaniesReviewAnswersListControllerSpec.scala
@@ -101,7 +101,7 @@ class UkCompaniesReviewAnswersListControllerSpec extends SpecBase with FeatureSw
         "redirect to the Next Page route" in {
 
           mockGetAnswers(Some(emptyUserAnswers
-            .set(ReviewAndCompletePage, ReviewAndCompleteModel(ukCompanies = SectionState(SectionStatus.InProgress, Some(ReviewAndCompletePage)))).get
+            .set(ReviewAndCompletePage, ReviewAndCompleteModel(ukCompanies = SectionState(SectionStatus.InProgress))).get
           ))
 
           val request = fakeRequest.withFormUrlEncodedBody(("value", "false"))

--- a/test/models/returnModels/ReviewAndCompleteModelSpec.scala
+++ b/test/models/returnModels/ReviewAndCompleteModelSpec.scala
@@ -16,11 +16,22 @@
 
 package models.returnModels
 
+import java.time.LocalDate
 import assets.constants.ReviewAndCompleteConstants._
 import org.scalatest.{MustMatchers, WordSpec}
 import play.api.libs.json.Json
+import pages.aboutReturn._
+import pages.groupLevelInformation._
+import pages.ultimateParentCompany._
+import pages.elections._
+import pages.groupLevelInformation._
+import pages.ukCompanies._
+import models.SectionStatus._
+import models.FullOrAbbreviatedReturn.Full
+import models.{CompanyDetailsModel, UserAnswers}
+import assets.constants.BaseConstants
 
-class ReviewAndCompleteModelSpec extends WordSpec with MustMatchers {
+class ReviewAndCompleteModelSpec extends WordSpec with MustMatchers with BaseConstants {
 
   "ReviewAndCompleteModel" must {
 
@@ -40,9 +51,53 @@ class ReviewAndCompleteModelSpec extends WordSpec with MustMatchers {
       actualValue mustBe expectedValue
     }
 
+    "determine current statuses as not started when instantiated at the start of the journey" in {
+
+      val userAnswers = UserAnswers("id")
+
+      val expectedModel = ReviewAndCompleteModel(
+        aboutReturnStatus = NotStarted,
+        electionsStatus = NotStarted,
+        groupLevelInformationStatus = NotStarted,
+        ultimateParentCompanyStatus = NotStarted,
+        ukCompaniesStatus = NotStarted,
+        checkTotalsStatus = NotStarted
+      )
+
+      ReviewAndCompleteModel(userAnswers) mustBe expectedModel
+
+    }
+
     "determine current statuses when instantiated" in {
 
-      1 mustBe 2
+      val companyDetails = CompanyDetailsModel(companyName = "name", ctutr = "1234567890")
+      val date = LocalDate.of(2020,1,1)
+
+      val userAnswers = UserAnswers("id")
+        .set(ReportingCompanyAppointedPage, true).get
+        .set(AgentActingOnBehalfOfCompanyPage, true).get
+        .set(AgentNamePage, agentName).get
+        .set(FullOrAbbreviatedReturnPage, Full).get
+        .set(RevisingReturnPage, true).get
+        .set(TellUsWhatHasChangedPage, "Something has changed").get
+        .set(ReportingCompanyNamePage, companyNameModel.name).get
+        .set(ReportingCompanyCTUTRPage, ctutrModel.utr).get
+        .set(AccountingPeriodPage, AccountingPeriodModel(date, date.plusMonths(1))).get
+        .set(ReportingCompanySameAsParentPage, true).get
+        .set(GroupRatioElectionPage, true).get
+        .set(GroupSubjectToRestrictionsPage, true).get
+        .set(CompanyDetailsPage, companyDetails).get
+
+      val expectedModel = ReviewAndCompleteModel(
+        aboutReturnStatus = Completed,
+        electionsStatus = InProgress,
+        groupLevelInformationStatus = InProgress,
+        ultimateParentCompanyStatus = Completed,
+        ukCompaniesStatus = InProgress,
+        checkTotalsStatus = NotStarted
+      )
+
+      ReviewAndCompleteModel(userAnswers) mustBe expectedModel
 
     }
   }

--- a/test/models/returnModels/ReviewAndCompleteModelSpec.scala
+++ b/test/models/returnModels/ReviewAndCompleteModelSpec.scala
@@ -39,5 +39,11 @@ class ReviewAndCompleteModelSpec extends WordSpec with MustMatchers {
 
       actualValue mustBe expectedValue
     }
+
+    "determine current statuses when instantiated" in {
+
+      1 mustBe 2
+
+    }
   }
 }

--- a/test/sectionstatus/CheckTotalsSectionStatusSpec.scala
+++ b/test/sectionstatus/CheckTotalsSectionStatusSpec.scala
@@ -18,7 +18,6 @@ package sectionstatus
 
 import base.SpecBase
 import models.SectionStatus._
-import pages.checkTotals.CompanyDetailsPage
 import assets.constants.BaseConstants
 
 class CheckTotalsSectionStatusSpec extends SpecBase with BaseConstants {

--- a/test/sectionstatus/CheckTotalsSectionStatusSpec.scala
+++ b/test/sectionstatus/CheckTotalsSectionStatusSpec.scala
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2021 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package sectionstatus
+
+import base.SpecBase
+import models.SectionStatus._
+import pages.checkTotals.CompanyDetailsPage
+import assets.constants.BaseConstants
+
+class CheckTotalsSectionStatusSpec extends SpecBase with BaseConstants {
+
+  "aboutReturnSectionStatus" must {
+    "return NotStarted" when {
+      "no data from the section has been entered" in {
+        val userAnswers = emptyUserAnswers
+        CheckTotalsSectionStatus.getStatus(userAnswers) mustEqual NotStarted
+      }
+    }
+    "return InProgress" when {
+    }
+    
+    "return Completed" when {     
+    }
+  }
+}

--- a/test/sectionstatus/UkCompaniesSectionStatusSpec.scala
+++ b/test/sectionstatus/UkCompaniesSectionStatusSpec.scala
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2021 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package sectionstatus
+
+import base.SpecBase
+import models.SectionStatus._
+import pages.ukCompanies.CompanyDetailsPage
+import assets.constants.BaseConstants
+import models.CompanyDetailsModel
+
+class UkCompaniesSectionStatusSpec extends SpecBase with BaseConstants {
+
+  "aboutReturnSectionStatus" must {
+    "return NotStarted" when {
+      "no data from the section has been entered" in {
+        val userAnswers = emptyUserAnswers
+        UkCompaniesSectionStatus.getStatus(userAnswers) mustEqual NotStarted
+      }
+    }
+    "return InProgress" when {
+      "has some data been entered" in {
+        val companyDetails = CompanyDetailsModel(companyName = "name", ctutr = "1234567890")
+        val userAnswers = emptyUserAnswers.set(CompanyDetailsPage, companyDetails).get
+        UkCompaniesSectionStatus.getStatus(userAnswers) mustEqual InProgress
+      }
+    }
+    
+    "return Completed" when {     
+    }
+  }
+}

--- a/test/utils/ReviewAndCompleteHelperSpec.scala
+++ b/test/utils/ReviewAndCompleteHelperSpec.scala
@@ -20,7 +20,7 @@ import assets.messages.{ReviewAndCompleteMessages, SectionHeaderMessages}
 import base.SpecBase
 import models.NormalMode
 import models.SectionStatus.{Completed, InProgress, NotStarted}
-import models.returnModels.{ReviewAndCompleteModel, SectionState}
+import models.returnModels.ReviewAndCompleteModel
 import pages.ultimateParentCompany.{HasDeemedParentPage, ReportingCompanySameAsParentPage}
 import viewmodels.{SummaryListRowHelper, TaskListRow}
 
@@ -28,12 +28,12 @@ import viewmodels.{SummaryListRowHelper, TaskListRow}
 class ReviewAndCompleteHelperSpec extends SpecBase with SummaryListRowHelper with CurrencyFormatter {
 
   lazy val reviewAndCompleteModel =   ReviewAndCompleteModel(
-    aboutReturn = SectionState(NotStarted),
-    elections = SectionState(InProgress),
-    groupLevelInformation = SectionState(NotStarted),
-    ultimateParentCompany = SectionState(Completed),
-    ukCompanies = SectionState(InProgress),
-    checkTotals = SectionState(Completed)
+    aboutReturnStatus = NotStarted,
+    electionsStatus = InProgress,
+    groupLevelInformationStatus = NotStarted,
+    ultimateParentCompanyStatus = Completed,
+    ukCompaniesStatus = InProgress,
+    checkTotalsStatus = Completed
   )
 
   "ReviewAndCompleteHelper().rows" when {

--- a/test/utils/ReviewAndCompleteHelperSpec.scala
+++ b/test/utils/ReviewAndCompleteHelperSpec.scala
@@ -21,21 +21,19 @@ import base.SpecBase
 import models.NormalMode
 import models.SectionStatus.{Completed, InProgress, NotStarted}
 import models.returnModels.{ReviewAndCompleteModel, SectionState}
-import pages.elections.GroupRatioBlendedElectionPage
-import pages.ultimateParentCompany.{CheckAnswersGroupStructurePage, HasDeemedParentPage, ReportingCompanySameAsParentPage}
-import pages.ukCompanies.{DerivedCompanyPage, UkCompaniesPage}
+import pages.ultimateParentCompany.{HasDeemedParentPage, ReportingCompanySameAsParentPage}
 import viewmodels.{SummaryListRowHelper, TaskListRow}
 
 
 class ReviewAndCompleteHelperSpec extends SpecBase with SummaryListRowHelper with CurrencyFormatter {
 
   lazy val reviewAndCompleteModel =   ReviewAndCompleteModel(
-    aboutReturn = SectionState(NotStarted, None),
-    elections = SectionState(InProgress, Some(GroupRatioBlendedElectionPage)),
-    groupLevelInformation = SectionState(NotStarted, None),
-    ultimateParentCompany = SectionState(Completed, Some(CheckAnswersGroupStructurePage)),
-    ukCompanies = SectionState(InProgress, Some(UkCompaniesPage)),
-    checkTotals = SectionState(Completed, Some(DerivedCompanyPage))
+    aboutReturn = SectionState(NotStarted),
+    elections = SectionState(InProgress),
+    groupLevelInformation = SectionState(NotStarted),
+    ultimateParentCompany = SectionState(Completed),
+    ukCompanies = SectionState(InProgress),
+    checkTotals = SectionState(Completed)
   )
 
   "ReviewAndCompleteHelper().rows" when {

--- a/test/views/reviewAndComplete/ReviewAndCompleteViewSpec.scala
+++ b/test/views/reviewAndComplete/ReviewAndCompleteViewSpec.scala
@@ -31,12 +31,12 @@ class ReviewAndCompleteViewSpec extends ViewBehaviours {
 
   val taskListRows: Seq[TaskListRow] = new ReviewAndCompleteHelper().rows(
     ReviewAndCompleteModel(
-      aboutReturn = SectionState(NotStarted, None),
-      elections = SectionState(InProgress, Some(GroupRatioBlendedElectionPage)),
-      groupLevelInformation = SectionState(Completed, Some(GroupSubjectToRestrictionsPage)),
-      ultimateParentCompany = SectionState(NotStarted, None),
-      ukCompanies = SectionState(InProgress, Some(UkCompaniesPage)),
-      checkTotals = SectionState(Completed, Some(DerivedCompanyPage))
+      aboutReturn = SectionState(NotStarted),
+      elections = SectionState(InProgress),
+      groupLevelInformation = SectionState(Completed),
+      ultimateParentCompany = SectionState(NotStarted),
+      ukCompanies = SectionState(InProgress),
+      checkTotals = SectionState(Completed)
     ),
     emptyUserAnswers
   )

--- a/test/views/reviewAndComplete/ReviewAndCompleteViewSpec.scala
+++ b/test/views/reviewAndComplete/ReviewAndCompleteViewSpec.scala
@@ -18,7 +18,7 @@ package views.reviewAndComplete
 
 import assets.messages.BaseMessages
 import models.SectionStatus.{Completed, InProgress, NotStarted}
-import models.returnModels.{ReviewAndCompleteModel, SectionState}
+import models.returnModels.ReviewAndCompleteModel
 import pages.elections.GroupRatioBlendedElectionPage
 import pages.groupLevelInformation.GroupSubjectToRestrictionsPage
 import pages.ukCompanies.{DerivedCompanyPage, UkCompaniesPage}
@@ -31,12 +31,12 @@ class ReviewAndCompleteViewSpec extends ViewBehaviours {
 
   val taskListRows: Seq[TaskListRow] = new ReviewAndCompleteHelper().rows(
     ReviewAndCompleteModel(
-      aboutReturn = SectionState(NotStarted),
-      elections = SectionState(InProgress),
-      groupLevelInformation = SectionState(Completed),
-      ultimateParentCompany = SectionState(NotStarted),
-      ukCompanies = SectionState(InProgress),
-      checkTotals = SectionState(Completed)
+      aboutReturnStatus = NotStarted,
+      electionsStatus = InProgress,
+      groupLevelInformationStatus = Completed,
+      ultimateParentCompanyStatus = NotStarted,
+      ukCompaniesStatus = InProgress,
+      checkTotalsStatus = Completed
     ),
     emptyUserAnswers
   )


### PR DESCRIPTION
The real change here is in:
app/models/returnModels/ReviewAndCompleteModel.scala

We now have an apply method which accepts a UserAnswers which calls each SectionStatus.getStatus method to retrieve the current status.

This constructor is called in the ReviewAndCompleteController to pass into the ReviewAndCompleteHelper to populate the rows.