### PR TITLE
CIR-1381 - Fix error for dates

### DIFF
--- a/app/controllers/ukCompanies/CompanyAccountingPeriodEndDateController.scala
+++ b/app/controllers/ukCompanies/CompanyAccountingPeriodEndDateController.scala
@@ -49,7 +49,7 @@ class CompanyAccountingPeriodEndDateController @Inject()(
     answerFor(UkCompaniesPage, idx) { ukCompany =>
       answerFor(AccountingPeriodPage) { accountingPeriod =>
         Future.successful(Ok(view(
-          form = fillForm(CompanyAccountingPeriodEndDatePage(idx, restrictionIdx), formProvider(accountingPeriod.endDate)), 
+          form = fillForm(CompanyAccountingPeriodEndDatePage(idx, restrictionIdx), formProvider(accountingPeriod.startDate)), 
           companyName = ukCompany.companyDetails.companyName,
           postAction = routes.CompanyAccountingPeriodEndDateController.onSubmit(idx, restrictionIdx, mode)
         )))
@@ -60,7 +60,7 @@ class CompanyAccountingPeriodEndDateController @Inject()(
   def onSubmit(idx: Int, restrictionIdx: Int, mode: Mode): Action[AnyContent] = (identify andThen getData andThen requireData).async { implicit request =>
     answerFor(UkCompaniesPage, idx) { ukCompany =>
       answerFor(AccountingPeriodPage) { accountingPeriod =>
-        formProvider(accountingPeriod.endDate).bindFromRequest().fold(
+        formProvider(accountingPeriod.startDate).bindFromRequest().fold(
           formWithErrors =>
             Future.successful(
               BadRequest(view(

--- a/app/views/components/inputDate.scala.html
+++ b/app/views/components/inputDate.scala.html
@@ -35,7 +35,7 @@
             )
         )
     )),
-    id = Some(id),
+    id = id,
     items = Seq(
         InputItem(
             classes = "govuk-input--width-2",


### PR DESCRIPTION
The id field of this class isn't an option and it gets parsed weirdly as:

"Some(" + id + ")"

This made the id for a lot of elements weird (e.g. our base id was `date` and so for the day input it was `Some(date)-value.day`) and the error link didn't point to the right id.